### PR TITLE
Incluir campos de dados não estruturados no Journal

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -159,11 +159,11 @@ class Document:
 
         :param data_url: é a URL para a nova versão do documento.
         :param assets_getter: (optional) função que recebe 2 argumentos: 1)
-        a URL do XML do documento e 2) o timeout para a requisição e retorna 
+        a URL do XML do documento e 2) o timeout para a requisição e retorna
         o par ``(xml, [(href, xml_node), ...]`` onde ``xml`` é uma instância
         de *element tree* da *lxml* e ``[(href, xml_node), ...]`` é uma lista
         que associa as URIs dos ativos com os nós do XML onde se encontram.
-        Essa função deve ainda lançar as ``RetryableError`` e 
+        Essa função deve ainda lançar as ``RetryableError`` e
         ``NonRetryableError`` para representar problemas no acesso aos dados
         do XML.
         """
@@ -184,7 +184,7 @@ class Document:
 
     def _link_assets(self, tolink: list) -> dict:
         """Retorna um mapa entre as chaves dos ativos em `tolink` e as
-        referências já existentes na última versão. 
+        referências já existentes na última versão.
         """
         try:
             latest_version = self.version()
@@ -216,11 +216,11 @@ class Document:
         """Obtém os metadados da versão no momento `timestamp`.
 
         :param timestamp: string de texto do timestamp UTC ISO 8601 no formato
-        `YYYY-MM-DDTHH:MM:SSSSSSZ`. A resolução pode variar desde o dia, e.g., 
-        `2018-09-17`, dia horas e minutos, e.g., `2018-09-17T14:25Z`, ou dia 
-        horas minutos segundos (e frações em até 6 casas decimais). Caso a 
-        resolução esteja no nível do dia, a mesma será ajustada automaticamente 
-        para o nível dos microsegundos por meio da concatenação da string 
+        `YYYY-MM-DDTHH:MM:SSSSSSZ`. A resolução pode variar desde o dia, e.g.,
+        `2018-09-17`, dia horas e minutos, e.g., `2018-09-17T14:25Z`, ou dia
+        horas minutos segundos (e frações em até 6 casas decimais). Caso a
+        resolução esteja no nível do dia, a mesma será ajustada automaticamente
+        para o nível dos microsegundos por meio da concatenação da string
         `T23:59:59:999999Z` ao valor de `timestamp`.
         """
         if not re.match(self._timestamp_pattern, timestamp):
@@ -264,11 +264,11 @@ class Document:
         assets_getter=assets_from_remote_xml,
         timeout=2,
     ) -> bytes:
-        """Retorna o conteúdo do XML, codificado em UTF-8, já com as 
+        """Retorna o conteúdo do XML, codificado em UTF-8, já com as
         referências aos ativos digitais correspondendo às da versão solicitada.
 
-        Por meio dos argumentos `version_index` e `version_at` é possível 
-        explicitar a versão desejada a partir de 2 estratégias distintas: 
+        Por meio dos argumentos `version_index` e `version_at` é possível
+        explicitar a versão desejada a partir de 2 estratégias distintas:
         `version_index` recebe um valor inteiro referente ao índice da versão
         desejada (pense no acesso a uma lista de versões). Já o argumento
         `version_at` recebe um timestamp UTC, em formato textual, e retorna
@@ -276,7 +276,7 @@ class Document:
         mutuamente exclusivos, e `version_at` anula a presença do outro.
 
         Note que o argumento `version_at` é muito mais poderoso, uma vez que,
-        diferentemente do `version_index`, também recupera o estado desejado 
+        diferentemente do `version_index`, também recupera o estado desejado
         no nível dos ativos digitais do documento.
         """
         version = (
@@ -292,7 +292,7 @@ class Document:
         return etree.tostring(xml_tree, encoding="utf-8", pretty_print=False)
 
     def new_asset_version(self, asset_id, data_url) -> None:
-        """Adiciona `data_url` como uma nova versão do ativo `asset_id` vinculado 
+        """Adiciona `data_url` como uma nova versão do ativo `asset_id` vinculado
         a versão mais recente do documento. É importante notar que nenhuma validação
         será executada em `data_url`.
         """
@@ -351,11 +351,9 @@ class BundleManifest:
 
     @staticmethod
     def add_item(bundle: dict, item: str, now: Callable[[], str] = utcnow) -> dict:
-        bundle_type = "documents"
         if item in bundle["items"]:
             raise exceptions.AlreadyExists(
-                "cannot add documents bundle item "
-                '"%s": the item already exists' % item
+                'cannot add item "%s" in bundle: ' "the item already exists" % item
             )
         _bundle = deepcopy(bundle)
         _bundle["items"].append(item)
@@ -364,36 +362,34 @@ class BundleManifest:
 
     @staticmethod
     def insert_item(
-        documents_bundle: dict, index: int, item: str, now: Callable[[], str] = utcnow
+        items_bundle: dict, index: int, item: str, now: Callable[[], str] = utcnow
     ) -> dict:
-        if item in documents_bundle["items"]:
+        if item in items_bundle["items"]:
             raise exceptions.AlreadyExists(
-                "cannot insert documents bundle item "
-                '"%s": the item already exists' % item
+                'cannot insert item "%s" in bundle: ' "the item already exists" % item
             )
-        _documents_bundle = deepcopy(documents_bundle)
-        _documents_bundle["items"].insert(index, item)
-        _documents_bundle["updated"] = now()
-        return _documents_bundle
+        _items_bundle = deepcopy(items_bundle)
+        _items_bundle["items"].insert(index, item)
+        _items_bundle["updated"] = now()
+        return _items_bundle
 
     @staticmethod
     def remove_item(
-        documents_bundle: dict, item: str, now: Callable[[], str] = utcnow
+        items_bundle: dict, item: str, now: Callable[[], str] = utcnow
     ) -> dict:
-        if item not in documents_bundle["items"]:
+        if item not in items_bundle["items"]:
             raise exceptions.DoesNotExist(
-                "cannot remove documents bundle item "
-                '"%s": the item does not exist' % item
+                'cannot remove item "%s" from bundle: ' "the item does not exist" % item
             )
-        _documents_bundle = deepcopy(documents_bundle)
-        _documents_bundle["items"].remove(item)
-        _documents_bundle["updated"] = now()
-        return _documents_bundle
+        _items_bundle = deepcopy(items_bundle)
+        _items_bundle["items"].remove(item)
+        _items_bundle["updated"] = now()
+        return _items_bundle
 
 
 class DocumentsBundle:
     """
-    DocumentsBundle representa um conjunto de documentos agnóstico ao modelo de 
+    DocumentsBundle representa um conjunto de documentos agnóstico ao modelo de
     publicação. Exemplos de publicação que são DocumentsBundle: Fascículos fechados
     e abertos, Ahead of Print, Documentos Provisórios, Erratas e Retratações.
     """
@@ -470,3 +466,25 @@ class DocumentsBundle:
     @property
     def documents(self):
         return self._manifest["items"]
+
+
+class Journal:
+    """
+    Journal representa um periodico cientifico que contem um conjunto de documentos
+    DocumentsBundle.
+    """
+
+    def __init__(self, id: str = None, manifest: dict = None):
+        assert any([id, manifest])
+        self.manifest = manifest or BundleManifest.new(id)
+
+    def id(self):
+        return self.manifest.get("id", "")
+
+    @property
+    def manifest(self):
+        return deepcopy(self._manifest)
+
+    @manifest.setter
+    def manifest(self, value: dict):
+        self._manifest = value

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -333,7 +333,10 @@ class BundleManifest:
 
     @staticmethod
     def set_metadata(
-        bundle: dict, name: str, value: str, now: Callable[[], str] = utcnow
+        bundle: dict,
+        name: str,
+        value: Union[dict, str],
+        now: Callable[[], str] = utcnow,
     ) -> dict:
         _bundle = deepcopy(bundle)
         _now = now()
@@ -488,3 +491,15 @@ class Journal:
     @manifest.setter
     def manifest(self, value: dict):
         self._manifest = value
+
+    @property
+    def mission(self):
+        return self._manifest["metadata"].get("mission", {})
+
+    @mission.setter
+    def mission(self, value: dict):
+        if not isinstance(value, dict):
+            raise ValueError(
+                "cannot set mission with value " '"%s": the value is not valid' % value
+            )
+        self.manifest = BundleManifest.set_metadata(self._manifest, "mission", value)

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -235,7 +235,7 @@ class Document:
         try:
             target_version = max(
                 itertools.takewhile(
-                    lambda version: version.get("timestamp", "") <= timestamp,
+                    lambda version: version.get("timestamp") <= timestamp,
                     self.manifest["versions"],
                 ),
                 key=lambda version: version.get("timestamp"),
@@ -402,7 +402,7 @@ class DocumentsBundle:
         self.manifest = manifest or BundleManifest.new(id)
 
     def id(self):
-        return self.manifest.get("id", "")
+        return self.manifest.get("id")
 
     @property
     def manifest(self):
@@ -494,7 +494,7 @@ class Journal:
 
     @property
     def mission(self):
-        return self._manifest["metadata"].get("mission", {})
+        return BundleManifest.get_metadata(self._manifest, "mission", {})
 
     @mission.setter
     def mission(self, value: dict):
@@ -503,3 +503,133 @@ class Journal:
                 "cannot set mission with value " '"%s": the value is not valid' % value
             )
         self.manifest = BundleManifest.set_metadata(self._manifest, "mission", value)
+
+    @property
+    def title(self):
+        return BundleManifest.get_metadata(self._manifest, "title")
+
+    @title.setter
+    def title(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(self._manifest, "title", _value)
+
+    @property
+    def title_iso(self):
+        return BundleManifest.get_metadata(self._manifest, "title_iso")
+
+    @title_iso.setter
+    def title_iso(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(self._manifest, "title_iso", _value)
+
+    @property
+    def short_title(self):
+        return BundleManifest.get_metadata(self._manifest, "short_title")
+
+    @short_title.setter
+    def short_title(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "short_title", _value
+        )
+
+    @property
+    def title_slug(self):
+        return BundleManifest.get_metadata(self._manifest, "volume")
+
+    @title_slug.setter
+    def title_slug(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "title_slug", _value
+        )
+
+    @property
+    def acronym(self):
+        return BundleManifest.get_metadata(self._manifest, "acronym")
+
+    @acronym.setter
+    def acronym(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(self._manifest, "acronym", _value)
+
+    @property
+    def scielo_issn(self):
+        return BundleManifest.get_metadata(self._manifest, "scielo_issn")
+
+    @scielo_issn.setter
+    def scielo_issn(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "scielo_issn", _value
+        )
+
+    @property
+    def print_issn(self):
+        return BundleManifest.get_metadata(self._manifest, "print_issn")
+
+    @print_issn.setter
+    def print_issn(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "print_issn", _value
+        )
+
+    @property
+    def eletronic_issn(self):
+        return BundleManifest.get_metadata(self._manifest, "eletronic_issn")
+
+    @eletronic_issn.setter
+    def eletronic_issn(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "eletronic_issn", _value
+        )
+
+    @property
+    def current_status(self):
+        return BundleManifest.get_metadata(self._manifest, "current_status")
+
+    @current_status.setter
+    def current_status(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "current_status", _value
+        )
+
+    @property
+    def unpublish_reason(self):
+        return BundleManifest.get_metadata(self._manifest, "unpublish_reason")
+
+    @unpublish_reason.setter
+    def unpublish_reason(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "unpublish_reason", _value
+        )
+
+    @property
+    def is_public(self):
+        return BundleManifest.get_metadata(self._manifest, "is_public", True)
+
+    @is_public.setter
+    def is_public(self, value: bool):
+        self.manifest = BundleManifest.set_metadata(self._manifest, "is_public", value)
+
+    @property
+    def created(self):
+        return BundleManifest.get_metadata(self._manifest, "created")
+
+    @created.setter
+    def created(self, value: Union[str, datetime]):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(self._manifest, "created", _value)
+
+    @property
+    def updated(self):
+        return BundleManifest.get_metadata(self._manifest, "updated", True)
+
+    @updated.setter
+    def updated(self, value: Union[str, datetime]):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(self._manifest, "updated", _value)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -347,8 +347,8 @@ class BundleManifestTest(UnittestMixin, unittest.TestCase):
         current_item_len = len(documents_bundle["items"])
         self._assert_raises_with_message(
             exceptions.AlreadyExists,
-            "cannot add documents bundle item "
-            '"/documents/0034-8910-rsp-48-2-0275": the item already exists',
+            'cannot add item "/documents/0034-8910-rsp-48-2-0275" in bundle: '
+            "the item already exists",
             domain.BundleManifest.add_item,
             documents_bundle,
             "/documents/0034-8910-rsp-48-2-0275",
@@ -382,8 +382,8 @@ class BundleManifestTest(UnittestMixin, unittest.TestCase):
         current_item_len = len(documents_bundle["items"])
         self._assert_raises_with_message(
             exceptions.AlreadyExists,
-            "cannot insert documents bundle item "
-            '"/documents/0034-8910-rsp-48-2-0775": the item already exists',
+            'cannot insert item "/documents/0034-8910-rsp-48-2-0775" in bundle: '
+            "the item already exists",
             domain.BundleManifest.insert_item,
             documents_bundle,
             0,
@@ -430,8 +430,8 @@ class BundleManifestTest(UnittestMixin, unittest.TestCase):
         current_item_len = len(documents_bundle["items"])
         self._assert_raises_with_message(
             exceptions.DoesNotExist,
-            "cannot remove documents bundle item "
-            '"/documents/0034-8910-rsp-48-2-0775": the item does not exist',
+            'cannot remove item "/documents/0034-8910-rsp-48-2-0775" from bundle: '
+            "the item does not exist",
             domain.BundleManifest.remove_item,
             documents_bundle,
             "/documents/0034-8910-rsp-48-2-0775",
@@ -574,8 +574,8 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
         documents_bundle.add_document("/documents/0034-8910-rsp-48-2-0275")
         self._assert_raises_with_message(
             exceptions.AlreadyExists,
-            "cannot add documents bundle item "
-            '"/documents/0034-8910-rsp-48-2-0275": the item already exists',
+            'cannot add item "/documents/0034-8910-rsp-48-2-0275" in bundle: '
+            "the item already exists",
             documents_bundle.add_document,
             "/documents/0034-8910-rsp-48-2-0275",
         )
@@ -615,8 +615,8 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
         documents_bundle.add_document("/documents/0034-8910-rsp-48-2-0277")
         self._assert_raises_with_message(
             exceptions.DoesNotExist,
-            "cannot remove documents bundle item "
-            '"/documents/0034-8910-rsp-48-2-0275": the item does not exist',
+            'cannot remove item "/documents/0034-8910-rsp-48-2-0275" from bundle: '
+            "the item does not exist",
             documents_bundle.remove_document,
             "/documents/0034-8910-rsp-48-2-0275",
         )
@@ -637,9 +637,29 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
         documents_bundle.add_document("/documents/0034-8910-rsp-48-2-0275")
         self._assert_raises_with_message(
             exceptions.AlreadyExists,
-            "cannot insert documents bundle item "
-            '"/documents/0034-8910-rsp-48-2-0275": the item already exists',
+            'cannot insert item "/documents/0034-8910-rsp-48-2-0275" in bundle: '
+            "the item already exists",
             documents_bundle.insert_document,
             1,
             "/documents/0034-8910-rsp-48-2-0275",
         )
+
+
+class JournalTest(UnittestMixin, unittest.TestCase):
+    def test_manifest_is_generated_on_init(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertTrue(isinstance(journal.manifest, dict))
+
+    def test_manifest_as_arg_on_init(self):
+        existing_manifest = new_bundle("0034-8910-rsp-48-2")
+        journal = domain.Journal(manifest=existing_manifest)
+        self.assertEqual(existing_manifest, journal.manifest)
+
+    def test_manifest_schema_is_not_validated_on_init(self):
+        existing_manifest = {"versions": []}
+        journal = domain.Journal(manifest=existing_manifest)
+        self.assertEqual(existing_manifest, journal.manifest)
+
+    def test_id_returns_id(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.id(), "0034-8910-rsp-48-2")

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -699,3 +699,154 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "mission",
             "mission-invalid",
         )
+
+    def test_title_is_empty_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.title, "")
+
+    def test_set_title(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.title = 'Rev. Saúde Pública'
+
+        self.assertEqual(journal.title, "Rev. Saúde Pública")
+        self.assertEqual(
+            journal.manifest["metadata"]["title"],
+            [("2018-08-05T22:33:49.795151Z", "Rev. Saúde Pública")],
+        )
+
+    def test_title_iso_is_empty_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.title_iso, "")
+
+    def test_set_title_iso(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.title_iso = 'Rev. Saúde Pública'
+
+        self.assertEqual(journal.title_iso, "Rev. Saúde Pública")
+        self.assertEqual(
+            journal.manifest["metadata"]["title_iso"],
+            [("2018-08-05T22:33:49.795151Z", "Rev. Saúde Pública")],
+        )
+
+    def test_short_title_is_empty_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.short_title, "")
+
+    def test_set_short_title(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.short_title = 'Rev. Saúde Pública'
+
+        self.assertEqual(journal.short_title, "Rev. Saúde Pública")
+        self.assertEqual(
+            journal.manifest["metadata"]["short_title"],
+            [("2018-08-05T22:33:49.795151Z", "Rev. Saúde Pública")],
+        )
+
+    def test_title_slug_is_empty_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.title_slug, "")
+
+    def test_set_title_slug(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.title_slug = "pesquisa-veterinaria-brasileira"
+        self.assertEqual(journal.title_slug, "pesquisa-veterinaria-brasileira")
+        self.assertEqual(
+            journal.manifest["metadata"]["title_slug"],
+            [("2018-08-05T22:33:49.795151Z", "pesquisa-veterinaria-brasileira")],
+        )
+
+    def test_acronym_is_empty_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.acronym, "")
+
+    def test_set_acronym_slug(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.acronym = "rsp"
+        self.assertEqual(journal.acronym, "rsp")
+        self.assertEqual(
+            journal.manifest["metadata"]["acronym"],
+            [("2018-08-05T22:33:49.795151Z", "rsp")],
+        )
+
+    def test_scielo_issn_is_empty_str(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.scielo_issn, "")
+
+    def test_set_scielo_issn(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        journal.scielo_issn = "1809-4392"
+        self.assertEqual(journal.scielo_issn, "1809-4392")
+        self.assertEqual(
+            journal.manifest["metadata"]["scielo_issn"],
+            [("2018-08-05T22:33:49.795151Z", "1809-4392")],
+        )
+
+    def test_print_issn_is_empty_str(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.print_issn, "")
+
+    def test_set_print_issn(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        journal.print_issn = "1809-4392"
+        self.assertEqual(journal.print_issn, "1809-4392")
+        self.assertEqual(
+            journal.manifest["metadata"]["print_issn"],
+            [("2018-08-05T22:33:49.795151Z", "1809-4392")],
+        )
+
+    def test_eletronic_issn_is_empty_str(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.eletronic_issn, "")
+
+    def test_set_eletronic_issn(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        journal.eletronic_issn = "1809-4392"
+        self.assertEqual(journal.eletronic_issn, "1809-4392")
+        self.assertEqual(
+            journal.manifest["metadata"]["eletronic_issn"],
+            [("2018-08-05T22:33:49.795151Z", "1809-4392")],
+        )
+
+    def test_current_status_is_empty_str(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.current_status, "")
+
+    def test_set_current_status(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        journal.current_status = "current"
+        self.assertEqual(journal.current_status, "current")
+        self.assertEqual(
+            journal.manifest["metadata"]["current_status"],
+            [("2018-08-05T22:33:49.795151Z", "current")],
+        )
+
+    def test_unpublish_reason_is_empty_str(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.unpublish_reason, "")
+
+    def test_set_unpublish_reason(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        journal.unpublish_reason = "not-open-access"
+        self.assertEqual(journal.unpublish_reason, "not-open-access")
+        self.assertEqual(
+            journal.manifest["metadata"]["unpublish_reason"],
+            [("2018-08-05T22:33:49.795151Z", "not-open-access")],
+        )
+
+    def test_is_public_is_empty_str(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.is_public, "")
+
+    def test_set_is_public(self):
+        journal = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        journal.is_public = True
+        self.assertTrueEqual(journal.is_public)
+        self.assertEqual(
+            journal.manifest["metadata"]["is_public"],
+            [("2018-08-05T22:33:49.795151Z", True)],
+        )
+
+
+
+# created
+# updated

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -663,3 +663,39 @@ class JournalTest(UnittestMixin, unittest.TestCase):
     def test_id_returns_id(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
         self.assertEqual(journal.id(), "0034-8910-rsp-48-2")
+
+    def test_set_mission(self):
+        documents_bundle = domain.Journal(id="0034-8910-rsp-48-2")
+        documents_bundle.mission = {
+            "pt": "Publicar trabajos científicos originales sobre Amazonia.",
+            "es": "Publicar trabalhos científicos originais sobre a Amazonia.",
+            "en": "To publish original scientific papers about Amazonia.",
+        }
+        self.assertEqual(
+            documents_bundle.mission,
+            {
+                "pt": "Publicar trabajos científicos originales sobre Amazonia.",
+                "es": "Publicar trabalhos científicos originais sobre a Amazonia.",
+                "en": "To publish original scientific papers about Amazonia.",
+            },
+        )
+        self.assertEqual(
+            documents_bundle.manifest["metadata"]["mission"],
+            {
+                "pt": "Publicar trabajos científicos originales sobre Amazonia.",
+                "es": "Publicar trabalhos científicos originais sobre a Amazonia.",
+                "en": "To publish original scientific papers about Amazonia.",
+            },
+        )
+
+    def test_set_mission_content_is_not_validated(self):
+        documents_bundle = domain.Journal(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            ValueError,
+            "cannot set mission with value "
+            '"mission-invalid": the value is not valid',
+            setattr,
+            documents_bundle,
+            "mission",
+            "mission-invalid",
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Incluir campos de dados não estruturados (texto, bool e datetime) no journal domain

#### Onde a revisão poderia começar?
revisando o código do domain.py 

#### Como este poderia ser testado manualmente?
rodando os testes no terminal 

#### Quais são tickets relevantes?
https://github.com/scieloorg/document-store/issues/8