### PR TITLE
Reduz acoplamento em domain.Journal().mission

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -498,8 +498,10 @@ class Journal:
 
     @mission.setter
     def mission(self, value: dict):
-        if not isinstance(value, dict):
-            raise ValueError(
-                "cannot set mission with value " '"%s": the value is not valid' % value
-            )
+        try:
+            value = dict(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                "cannot set mission with value " '"%s": value must be dict' % value
+            ) from None
         self.manifest = BundleManifest.set_metadata(self._manifest, "mission", value)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -704,9 +704,8 @@ class JournalTest(UnittestMixin, unittest.TestCase):
     def test_set_mission_content_is_not_validated(self):
         documents_bundle = domain.Journal(id="0034-8910-rsp-48-2")
         self._assert_raises_with_message(
-            ValueError,
-            "cannot set mission with value "
-            '"mission-invalid": the value is not valid',
+            TypeError,
+            "cannot set mission with value " '"mission-invalid": value must be dict',
             setattr,
             documents_bundle,
             "mission",


### PR DESCRIPTION
#### O que esse PR faz?
O ponto principal desta modificação é a redução do acoplamento do método
com o tipo `dict` maximizando o polimorfismo no nível do argumento.

Casos que passam a ser aceitos com a modificação:

  1. Objetos que implementam parte da interface de dict (método `__getitem__`);
  2. Listas associativas: `j.mission = [("en": "destroy planet earth")]`

Além disso, esta mudança também ajusta o tipo e a mensagem da exceção retornada
quando o valor atribuído é de um tipo inválido. A versão anterior
levantava a excessão `ValueError` entretanto a mais correta semanticamente é
a `TypeError`.

#### Onde a revisão poderia começar?
Poucas linhas modificadas. Saber onde começar não será um problema ;)

#### Como este poderia ser testado manualmente?
`>>> python setup.py test`

#### Quais são tickets relevantes?
não há
