### PR TITLE
Alteração da grafia do metodo 'eletronic_issn' para 'electronic_issn'

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -582,14 +582,14 @@ class Journal:
         )
 
     @property
-    def eletronic_issn(self):
-        return BundleManifest.get_metadata(self._manifest, "eletronic_issn")
+    def electronic_issn(self):
+        return BundleManifest.get_metadata(self._manifest, "electronic_issn")
 
-    @eletronic_issn.setter
-    def eletronic_issn(self, value: str):
+    @electronic_issn.setter
+    def electronic_issn(self, value: str):
         _value = str(value)
         self.manifest = BundleManifest.set_metadata(
-            self._manifest, "eletronic_issn", _value
+            self._manifest, "electronic_issn", _value
         )
 
     @property

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -807,16 +807,16 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             [("2018-08-05T22:33:49.795151Z", "1809-4392")],
         )
 
-    def test_eletronic_issn_is_empty_str(self):
+    def test_electronic_issn_is_empty_str(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
-        self.assertEqual(journal.eletronic_issn, "")
+        self.assertEqual(journal.electronic_issn, "")
 
-    def test_set_eletronic_issn(self):
+    def test_set_electronic_issn(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
-        journal.eletronic_issn = "1809-4392"
-        self.assertEqual(journal.eletronic_issn, "1809-4392")
+        journal.electronic_issn = "1809-4392"
+        self.assertEqual(journal.electronic_issn, "1809-4392")
         self.assertEqual(
-            journal.manifest["metadata"]["eletronic_issn"],
+            journal.manifest["metadata"]["electronic_issn"],
             [("2018-08-05T22:33:49.795151Z", "1809-4392")],
         )
 


### PR DESCRIPTION
#### O que esse PR faz?
Alteração da grafia do metodo `eletronic_issn` para `electronic_issn`

#### Onde a revisão poderia começar?
pelo arquivos `domain.py` e `test_domain.py`

#### Como este poderia ser testado manualmente?
`python setup.py test`

#### Algum cenário de contexto que queira dar?
A @robertatakenaka , comentou que esse metodo estava grafado `eletronic_issn` devido a uma erro de grafia antigo que aconteceu no desenvolvimento do opac_schema, mas como estamos construindo um mecanismo novo devíamos corrigir esse erro.

#### Quais são tickets relevantes?
#8 