### PR TITLE
[tk10][Domain][Journal]Incluir campo para áreas de conhecimento

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -20,6 +20,17 @@ DEFAULT_XMLPARSER = etree.XMLParser(
     collect_ids=False,
 )
 
+SUBJECT_AREAS = (
+    "AGRICULTURAL SCIENCES",
+    "APPLIED SOCIAL SCIENCES",
+    "BIOLOGICAL SCIENCES",
+    "ENGINEERING",
+    "EXACT AND EARTH SCIENCES",
+    "HEALTH SCIENCES",
+    "HUMAN SCIENCES",
+    "LINGUISTIC, LITERATURE AND ARTS",
+)
+
 
 def utcnow():
     return str(datetime.utcnow().isoformat() + "Z")
@@ -623,3 +634,26 @@ class Journal:
     @is_public.setter
     def is_public(self, value: bool):
         self.manifest = BundleManifest.set_metadata(self._manifest, "is_public", value)
+
+    @property
+    def subject_areas(self):
+        return BundleManifest.get_metadata(self._manifest, "subject_areas")
+
+    @subject_areas.setter
+    def subject_areas(self, value: tuple):
+        try:
+            value = tuple(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                "cannot set subject_areas with value "
+                '"%s": value must be tuple' % repr(value)
+            ) from None
+        invalid = [item for item in value if item not in SUBJECT_AREAS]
+        if invalid:
+            raise ValueError(
+                "cannot set subject_areas with value %s: " % repr(value)
+                + "%s are not valid" % repr(invalid)
+            )
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "subject_areas", value
+        )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -889,3 +889,102 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         self.addCleanup(datetime_patcher.stop)
         journal.title = "Novo Journal"
         self.assertEqual(journal.updated(), "2018-08-05T22:34:49.795151Z")
+
+    def test_subject_areas(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.subject_areas = [
+            "AGRICULTURAL SCIENCES",
+            "APPLIED SOCIAL SCIENCES",
+            "BIOLOGICAL SCIENCES",
+            "ENGINEERING",
+            "EXACT AND EARTH SCIENCES",
+            "HEALTH SCIENCES",
+            "HUMAN SCIENCES",
+            "LINGUISTIC, LITERATURE AND ARTS",
+        ]
+        self.assertEqual(
+            journal.subject_areas,
+            (
+                "AGRICULTURAL SCIENCES",
+                "APPLIED SOCIAL SCIENCES",
+                "BIOLOGICAL SCIENCES",
+                "ENGINEERING",
+                "EXACT AND EARTH SCIENCES",
+                "HEALTH SCIENCES",
+                "HUMAN SCIENCES",
+                "LINGUISTIC, LITERATURE AND ARTS",
+            ),
+        )
+        self.assertEqual(
+            journal.manifest["metadata"]["subject_areas"][-1],
+            (
+                "2018-08-05T22:33:49.795151Z",
+                (
+                    "AGRICULTURAL SCIENCES",
+                    "APPLIED SOCIAL SCIENCES",
+                    "BIOLOGICAL SCIENCES",
+                    "ENGINEERING",
+                    "EXACT AND EARTH SCIENCES",
+                    "HEALTH SCIENCES",
+                    "HUMAN SCIENCES",
+                    "LINGUISTIC, LITERATURE AND ARTS",
+                ),
+            ),
+        )
+
+    def test_set_subject_areas_content_raises_type_error(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        invalid = 1
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set subject_areas with value "
+            '"%s": value must be tuple' % invalid,
+            setattr,
+            journal,
+            "subject_areas",
+            invalid,
+        )
+
+    def test_set_subject_areas_content_raises_value_error(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        subject_areas = (
+            "AGRICULTURAL",
+            "APPLIED SOCIAL",
+            "BIOLOGICAL",
+            "ENGINEERING",
+            "EXACT AND EARTH",
+            "HEALTH",
+            "HUMAN",
+            "LINGUISTIC, LITERATURE AND ARTS",
+        )
+        invalid = [
+            "AGRICULTURAL",
+            "APPLIED SOCIAL",
+            "BIOLOGICAL",
+            "EXACT AND EARTH",
+            "HEALTH",
+            "HUMAN",
+        ]
+        self._assert_raises_with_message(
+            ValueError,
+            "cannot set subject_areas with value %s: " % repr(subject_areas)
+            + "%s are not valid" % repr(invalid),
+            setattr,
+            journal,
+            "subject_areas",
+            subject_areas,
+        )
+
+    def test_set_subject_areas_content_raises_value_error_for_string(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        subject_areas = "LINGUISTIC, LITERATURE AND ARTS"
+        invalid = list(subject_areas)
+        self._assert_raises_with_message(
+            ValueError,
+            "cannot set subject_areas with value %s: " % repr(tuple(subject_areas))
+            + "%s are not valid" % repr(invalid),
+            setattr,
+            journal,
+            "subject_areas",
+            subject_areas,
+        )


### PR DESCRIPTION
#### What's this PR do?
Cria set e get para áreas do conhecimento (subject areas)

#### Where should the reviewer start?
test_domain.py

#### Any background context you want to provide?
As áreas são fixas e valem para todas e quaisquer coleções. São valores já adotados inclusive em relatórios para a FAPESP.
Os periódicos são classificados de acordo com estas áreas e pelo menos 1.

#### What are the relevant tickets?
#10 

#### Screenshots (if appropriate)
<img width="485" alt="captura de tela 2019-02-05 as 13 43 37" src="https://user-images.githubusercontent.com/505143/52284717-15b5cc80-294c-11e9-8d82-f5a386bbe7c8.png">
