### PR TITLE
Adiciona campo para as variações de título (other_titles)

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -2,7 +2,7 @@ import itertools
 from copy import deepcopy
 from io import BytesIO
 import re
-from typing import Union, Callable, Any
+from typing import Union, Callable, Any, List
 from datetime import datetime
 
 import requests
@@ -657,3 +657,21 @@ class Journal:
         self.manifest = BundleManifest.set_metadata(
             self._manifest, "subject_areas", value
         )
+
+    @property
+    def other_titles(self) -> List[str]:
+        return BundleManifest.get_metadata(self._manifest, "other_titles")
+
+    @other_titles.setter
+    def other_titles(self, value: List[str]):
+        try:
+            _value = list(value)
+        except TypeError:
+            raise TypeError(
+                "cannot set other_titles with value "
+                "%r: the value is not valid" % repr(value)
+            ) from None
+        else:
+            self.manifest = BundleManifest.set_metadata(
+                self._manifest, "other_titles", _value
+            )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -988,3 +988,37 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "subject_areas",
             subject_areas,
         )
+
+    def test_set_other_titles(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.other_titles = [
+            "Journal of Public Health",
+            "Rev. Saúde Pública",
+            "Rev. saúde pública",
+        ]
+        self.assertEqual(
+            journal.other_titles,
+            ["Journal of Public Health", "Rev. Saúde Pública", "Rev. saúde pública"],
+        )
+        self.assertEqual(
+            journal.manifest["metadata"]["other_titles"][-1],
+            (
+                "2018-08-05T22:33:49.795151Z",
+                [
+                    "Journal of Public Health",
+                    "Rev. Saúde Pública",
+                    "Rev. saúde pública",
+                ],
+            ),
+        )
+
+    def test_other_titles_content_is_not_valid(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set other_titles with value " "'123456': the value is not valid",
+            setattr,
+            journal,
+            "other_titles",
+            123456,
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona campo para manter as variações do título original (atualmente campo `other_titles`).

#### Onde a revisão poderia começar?
Em `domain.py`, na property `Journal.other_titles`

#### Como este poderia ser testado manualmente?
Ao criar uma nova instância de Journal, ao definir o atributo `other_titles`, ele deve se comportar como uma lista.

#### Algum cenário de contexto que queira dar?
N/A

#### Quais são tickets relevantes?
#11 
