### PR TITLE
Adiciona o campo sponsors para o domínio Journal

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -2,7 +2,7 @@ import itertools
 from copy import deepcopy
 from io import BytesIO
 import re
-from typing import Union, Callable, Any
+from typing import Union, Callable, Any, Tuple
 from datetime import datetime
 
 import requests
@@ -657,3 +657,16 @@ class Journal:
         self.manifest = BundleManifest.set_metadata(
             self._manifest, "subject_areas", value
         )
+
+    @property
+    def sponsors(self) -> Tuple[dict]:
+        return BundleManifest.get_metadata(self._manifest, "sponsors")
+
+    @sponsors.setter
+    def sponsors(self, value: Tuple[dict]) -> None:
+        try:
+            value = tuple([dict(sponsor) for sponsor in value])
+        except TypeError:
+            raise TypeError("cannot set sponsors this type %s" % repr(value)) from None
+
+        self.manifest = BundleManifest.set_metadata(self._manifest, "sponsors", value)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -988,3 +988,61 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "subject_areas",
             subject_areas,
         )
+
+    def test_set_sponsors(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.sponsors = (
+            {
+                "name": "FAPESP",
+                "url": "http://www.fapesp.br/",
+                "logo_path": "fixtures/imgs/fapesp.png",
+            },
+        )
+
+        self.assertEqual(
+            journal.sponsors,
+            (
+                {
+                    "name": "FAPESP",
+                    "url": "http://www.fapesp.br/",
+                    "logo_path": "fixtures/imgs/fapesp.png",
+                },
+            ),
+        )
+
+        self.assertEqual(
+            journal.manifest["metadata"]["sponsors"][-1],
+            (
+                "2018-08-05T22:33:49.795151Z",
+                (
+                    {
+                        "name": "FAPESP",
+                        "url": "http://www.fapesp.br/",
+                        "logo_path": "fixtures/imgs/fapesp.png",
+                    },
+                ),
+            ),
+        )
+
+    def test_set_sponsors_should_raise_type_error(self):
+        invalid_boolean_sponsors = ((True,),)
+        invalid_number_sponsors = ((1, 1.1),)
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set sponsors this type %s" % repr(invalid_boolean_sponsors),
+            setattr,
+            journal,
+            "sponsors",
+            invalid_boolean_sponsors,
+        )
+
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set sponsors this type %s" % repr(invalid_number_sponsors),
+            setattr,
+            journal,
+            "sponsors",
+            invalid_number_sponsors,
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Este commit adiciona o getter e setter para o atributo `sponsors` na classe `Journal` afim de reproduzir
o domínio de dados existente no opac_schema.

#### Onde a revisão poderia começar?
No arquivo `documentstore/domain.py`, na property `Journal.sponsors`

#### Como este poderia ser testado manualmente?
Ao criar uma nova instância de `Journal` pode-se:
-  Atribuir uma `tupla` contendo `dicts`. Esta atribuição deve validar o tipo do dado de entrada nas camadas externa e interna.
- Ao acessar a propriedade `sponsors` a instância deve retornar uma `tuple` vazia ou uma `tuple` contendo `dicts` ou ainda uma `str` vazia em caso de não atribuição anterior.

#### Algum cenário de contexto que queira dar?
N/A

#### Quais são tickets relevantes?
close #14