### PR TITLE
[Journal] Incluir campo para métricas no jornal domain #15

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -670,3 +670,17 @@ class Journal:
             raise TypeError("cannot set sponsors this type %s" % repr(value)) from None
 
         self.manifest = BundleManifest.set_metadata(self._manifest, "sponsors", value)
+
+    @property
+    def metrics(self):
+        return BundleManifest.get_metadata(self._manifest, "metrics", {})
+
+    @metrics.setter
+    def metrics(self, value: dict):
+        try:
+            value = dict(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                "cannot set metrics with value " '"%s": value must be dict' % value
+            ) from None
+        self.manifest = BundleManifest.set_metadata(self._manifest, "metrics", value)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1046,3 +1046,47 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "sponsors",
             invalid_number_sponsors,
         )
+
+    def test_metrics_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.metrics, {})
+
+    def test_set_metrics(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.metrics = {
+            "scimago": {"url": "http://scimago.org", "title": "Scimago"},
+            "google": {"total_h5": 10, "h5_median": 5, "h5_year": 2018},
+            "scielo": "valor medio",
+        }
+        self.assertEqual(
+            journal.metrics,
+            {
+                "scimago": {"url": "http://scimago.org", "title": "Scimago"},
+                "google": {"total_h5": 10, "h5_median": 5, "h5_year": 2018},
+                "scielo": "valor medio",
+            },
+        )
+        self.assertEqual(
+            journal.manifest["metadata"]["metrics"],
+            [
+                (
+                    "2018-08-05T22:33:49.795151Z",
+                    {
+                        "scimago": {"url": "http://scimago.org", "title": "Scimago"},
+                        "google": {"total_h5": 10, "h5_median": 5, "h5_year": 2018},
+                        "scielo": "valor medio",
+                    },
+                )
+            ],
+        )
+
+    def test_set_metrics_content_is_not_validated(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set metrics with value " '"metrics-invalid": value must be dict',
+            setattr,
+            journal,
+            "metrics",
+            "metrics-invalid",
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Inclui o campo para as métricas dos periódicos, que sera exibido no site 

#### Onde a revisão poderia começar?
revisando o `domain.py` e  o `test_domain.py`

#### Como este poderia ser testado manualmente?
python setup.py test

#### Quais são tickets relevantes?
#15 