### PR TITLE
[tk29] [Domain][Journal] Incluir campo para url do logo do periódico …

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -684,3 +684,16 @@ class Journal:
                 "cannot set metrics with value " '"%s": value must be dict' % value
             ) from None
         self.manifest = BundleManifest.set_metadata(self._manifest, "metrics", value)
+
+    @property
+    def logo_url(self):
+        return BundleManifest.get_metadata(self.manifest, "logo_url")
+
+    @logo_url.setter
+    def logo_url(self, value: str):
+        if not isinstance(value, str):
+            raise TypeError(
+                "cannot set logo_url with value "
+                '"%s": value must be str' % repr(value)
+            ) from None
+        self.manifest = BundleManifest.set_metadata(self.manifest, "logo_url", value)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1090,3 +1090,29 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "metrics",
             "metrics-invalid",
         )
+
+    def test_logo_url(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        url = "https://logo"
+        journal.logo_url = url
+        self.assertEqual(url, journal.logo_url)
+        self.assertEqual(
+            journal.manifest["metadata"]["logo_url"],
+            [("2018-08-05T22:33:49.795151Z", url)],
+        )
+
+    def test_logo_url_is_empty_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.logo_url, "")
+
+    def test_set_logo_url_raises_type_error(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        invalid = []
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set logo_url with value " '"%s": value must be str' % repr(invalid),
+            setattr,
+            journal,
+            "logo_url",
+            invalid,
+        )


### PR DESCRIPTION
…(url_logo)

#### O que esse PR faz?
Incluir um campo para url do logo do periódico

#### Onde a revisão poderia começar?
documentstore/domain.py

#### Como este poderia ser testado manualmente?
python setup.py test

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#29 

### Referências
N/A