### PR TITLE
Add subject_categories

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -689,7 +689,7 @@ class Journal:
     def subject_categories(self):
         return BundleManifest.get_metadata(self.manifest, "subject_categories")
 
-    @mission.setter
+    @subject_categories.setter
     def subject_categories(self, value: Union[list, tuple]):
         if not isinstance(value, (list, tuple)):
             raise TypeError(

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -691,10 +691,12 @@ class Journal:
 
     @subject_categories.setter
     def subject_categories(self, value: Union[list, tuple]):
-        if not isinstance(value, (list, tuple)):
+        try:
+            value = list(value)
+        except (TypeError, ValueError):
             raise TypeError(
                 "cannot set subject_categories with value "
-                '"%s": value must be list' % value
+                '"%s": value must be list like object' % value
             ) from None
 
         self.manifest = BundleManifest.set_metadata(

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -700,7 +700,7 @@ class Journal:
             ) from None
 
         self.manifest = BundleManifest.set_metadata(
-            self.manifest, "subject_categories", list(value)
+            self._manifest, "subject_categories", list(value)
         )
 
     @property

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -693,7 +693,7 @@ class Journal:
     def subject_categories(self, value: Union[list, tuple]):
         try:
             value = list(value)
-        except (TypeError, ValueError):
+        except TypeError:
             raise TypeError(
                 "cannot set subject_categories with value "
                 '"%s": value must be list like object' % value

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -684,3 +684,19 @@ class Journal:
                 "cannot set metrics with value " '"%s": value must be dict' % value
             ) from None
         self.manifest = BundleManifest.set_metadata(self._manifest, "metrics", value)
+
+    @property
+    def subject_categories(self):
+        return BundleManifest.get_metadata(self.manifest, "subject_categories")
+
+    @mission.setter
+    def subject_categories(self, value: Union[list, tuple]):
+        if not isinstance(value, (list, tuple)):
+            raise TypeError(
+                "cannot set subject_categories with value "
+                '"%s": value must be list' % value
+            ) from None
+
+        self.manifest = BundleManifest.set_metadata(
+            self.manifest, "subject_categories", list(value)
+        )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1090,3 +1090,51 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "metrics",
             "metrics-invalid",
         )
+
+    def test_set_subject_categories(self):
+        journal = domain.Journal(id="0234-8410-bjmbr-587-90")
+        categories = [
+            "Health Sciences Orthopedics",
+            "Human Sciences Psychology",
+            "Psychoanalysis",
+        ]
+        journal.subject_categories = categories
+        self.assertEqual(
+            journal.manifest["metadata"]["subject_categories"],
+            [("2018-08-05T22:33:49.795151Z", categories)],
+        )
+
+    def test_set_int_subject_categories_content_raises_type_error(self):
+        journal = domain.Journal(id="0234-8410-bjmbr-587-90")
+        invalid = 9
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set subject_categories with value "
+            '"%s": value must be list' % invalid,
+            setattr,
+            journal,
+            "subject_categories",
+            invalid,
+        )
+
+    def test_set_str_subject_categories_content_raises_type_error(self):
+        journal = domain.Journal(id="0234-8410-bjmbr-587-90")
+        invalid = "Health Sciences Orthopedics, Human Sciences Psychology"
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set subject_categories with value "
+            '"%s": value must be list' % invalid,
+            setattr,
+            journal,
+            "subject_categories",
+            invalid,
+        )
+
+    def test_set_tuple_subject_categories(self):
+        journal = domain.Journal(id="0234-8410-bjmbr-587-90")
+        categories = ("Health Sciences Orthopedics", "Human Sciences Psychology")
+        journal.subject_categories = categories
+        self.assertEqual(
+            journal.manifest["metadata"]["subject_categories"],
+            [("2018-08-05T22:33:49.795151Z", list(categories))],
+        )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1110,24 +1110,20 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         self._assert_raises_with_message(
             TypeError,
             "cannot set subject_categories with value "
-            '"%s": value must be list' % invalid,
+            '"%s": value must be list like object' % invalid,
             setattr,
             journal,
             "subject_categories",
             invalid,
         )
 
-    def test_set_str_subject_categories_content_raises_type_error(self):
+    def test_set_str_subject_categories(self):
         journal = domain.Journal(id="0234-8410-bjmbr-587-90")
-        invalid = "Health Sciences Orthopedics, Human Sciences Psychology"
-        self._assert_raises_with_message(
-            TypeError,
-            "cannot set subject_categories with value "
-            '"%s": value must be list' % invalid,
-            setattr,
-            journal,
-            "subject_categories",
-            invalid,
+        categories = "Health Sciences"
+        journal.subject_categories = categories
+        self.assertEqual(
+            journal.manifest["metadata"]["subject_categories"],
+            [("2018-08-05T22:33:49.795151Z", list(categories))],
         )
 
     def test_set_tuple_subject_categories(self):
@@ -1137,6 +1133,36 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         self.assertEqual(
             journal.manifest["metadata"]["subject_categories"],
             [("2018-08-05T22:33:49.795151Z", list(categories))],
+        )
+
+    def test_set_list_like_object_to_subject_categories(self):
+        journal = domain.Journal(id="0234-8410-bjmbr-587-90")
+
+        class Fibonacci:
+
+            def __init__(self, maximo=1000000):
+                self.current, self.p_element = 0, 1
+                self.maximo = maximo
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self.current > self.maximo:
+                    raise StopIteration
+
+                ret = self.current
+
+                self.current, self.p_element = self.p_element, self.current + self.p_element
+
+                return str(ret)
+
+        fib_obj = Fibonacci(maximo=10)
+
+        journal.subject_categories = fib_obj
+        self.assertEqual(
+            journal.manifest["metadata"]["subject_categories"],
+            [("2018-08-05T22:33:49.795151Z", ['0', '1', '1', '2', '3', '5', '8'])],
         )
 
     def test_institution_responsible_for_is_empty_str(self):


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o campo de categorias de assuntos

#### Onde a revisão poderia começar?
No arquivo: documentstore/domain.py

#### Como este poderia ser testado manualmente?
Realizando os testes com o comando: python setup.py test

#### Algum cenário de contexto que queira dar?
Não

### Screenshots
Não há. 

#### Quais são tickets relevantes?
#25 

### Referências
#25
