### PR TITLE
Adiciona o campo publishers para o domínio do Journal

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -684,3 +684,18 @@ class Journal:
                 "cannot set metrics with value " '"%s": value must be dict' % value
             ) from None
         self.manifest = BundleManifest.set_metadata(self._manifest, "metrics", value)
+
+    @property
+    def publishers(self):
+        return BundleManifest.get_metadata(self.manifest, "publishers")
+
+    @publishers.setter
+    def publishers(self, value: Tuple[dict]) -> None:
+        try:
+            value = tuple([dict(publisher) for publisher in value])
+        except TypeError:
+            raise TypeError(
+                "cannot set publishers with value: %s" % repr(value)
+            ) from None
+
+        self.manifest = BundleManifest.set_metadata(self._manifest, "publishers", value)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1090,3 +1090,45 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "metrics",
             "metrics-invalid",
         )
+
+    def test_set_publishers(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.publishers = (
+            {
+                "name": "Some random publisher",
+                "country": "Brazil",
+                "state": "SP",
+                "city": "São Paulo",
+                "address": "Random string address",
+                "telephone": "(11) 1111-1111",
+            },
+        )
+
+        self.assertEqual(
+            journal.publishers,
+            (
+                {
+                    "name": "Some random publisher",
+                    "country": "Brazil",
+                    "state": "SP",
+                    "city": "São Paulo",
+                    "address": "Random string address",
+                    "telephone": "(11) 1111-1111",
+                },
+            ),
+        )
+
+        journal.publishers = ({},)
+        self.assertEqual(journal.publishers, ({},))
+
+    def test_set_publishers_should_raise_type_error(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        publishers = ({}, True)
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set publishers with value: %s" % repr(publishers),
+            setattr,
+            journal,
+            "publishers",
+            publishers,
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Este commit adiciona o campo `publishers` ao domínio do `Journal`. Este campo se comporta como uma lista de dicionários e contrariamente ao opac schema que aceitava apenas um único publisher.

#### Onde a revisão poderia começar?
A revisão deve começar por `documentstore/domain.py`

#### Como este poderia ser testado manualmente?
A depender da disposição do revisor este código pode ser testado via instanciação de um objeto `journal` e assim realizar uma atribuição do campo `publishers` em forma de tupla ou lista.

De forma automática este commit pode ser testado via `python setup.py test`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #27 

### Referências
N/A