### PR TITLE
 #28 [Journal] Incluir campo para dados de contato do periódico

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -750,7 +750,24 @@ class Journal:
         self.manifest = BundleManifest.set_metadata(
             self._manifest, "previous_journal", value
         )
-        
+
     @property
     def status_history(self):
         return BundleManifest.get_metadata_all(self.manifest, "status")
+
+    @property
+    def contact(self) -> dict:
+        return BundleManifest.get_metadata(self.manifest, "contact", {})
+
+    @contact.setter
+    def contact(self, value: dict) -> None:
+        try:
+            value = dict(value)
+        except (TypeError, ValueError) as ex:
+            raise type(ex)(
+                "cannot set contact with value "
+                "%s"
+                ": value must be dict" % repr(value)
+            ) from None
+
+        self.manifest = BundleManifest.set_metadata(self._manifest, "contact", value)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1236,3 +1236,39 @@ class JournalTest(UnittestMixin, unittest.TestCase):
                 {"status": "CEASED"},
             ],
         )
+
+    def test_contact_is_empty_list(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.contact, {})
+
+    def test_set_contact(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+
+        data_journal = {
+            "name": "Faculdade de Saúde Pública da Universidade de São Paulo",
+            "country": "Brasil",
+            "state": "SP",
+            "city": "São Paulo",
+            "address": "Avenida Dr. Arnaldo, 715\n01246-904 São Paulo SP Brazil",
+            "phone_number": "+55 11 3061-7985",
+            "email": "revsp@usp.br",
+            "enable_contact": "true",
+        }
+
+        journal.contact = data_journal
+        self.assertEqual(journal.contact, data_journal)
+        self.assertEqual(
+            journal.manifest["metadata"]["contact"],
+            [("2018-08-05T22:33:49.795151Z", data_journal)],
+        )
+
+    def test_set_contact_content_is_not_validated(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            ValueError,
+            "cannot set contact with value 'contact-invalid': value must be dict",
+            setattr,
+            journal,
+            "contact",
+            "contact-invalid",
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Este commit adiciona o campo `contact` ao domínio do `Journal`. Este campo se comporta como um dicionários e contrariamente ao opac schema que aceitava apenas um único objeto.

#### Onde a revisão poderia começar?
A revisão deve começar por `documentstore/domain.py`

#### Como este poderia ser testado manualmente?
pode se gerar os teste atraves dos `python setup.py test`

#### Quais são tickets relevantes?
#28 