### PR TITLE
[Domain][Journal] Adiciona campo URL de submissão de manuscritos

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -704,3 +704,14 @@ class Journal:
         self.manifest = BundleManifest.set_metadata(
             self.manifest, "institution_responsible_for", value
         )
+
+    @property
+    def online_submission_url(self):
+        return BundleManifest.get_metadata(self.manifest, "online_submission_url")
+
+    @online_submission_url.setter
+    def online_submission_url(self, value: str):
+        _value = str(value)
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "online_submission_url", _value
+        )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1122,3 +1122,17 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
         journal.institution_responsible_for = ["USP", "SCIELO"]
         self.assertEqual(journal.institution_responsible_for, ("USP", "SCIELO"))
+
+    def test_set_online_submission_url(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        url = "http://mc04.manuscriptcentral.com/rsp-scielo"
+        journal.online_submission_url = url
+        self.assertEqual(journal.online_submission_url, url)
+        self.assertEqual(
+            journal.manifest["metadata"]["online_submission_url"],
+            [("2018-08-05T22:33:49.795151Z", url)],
+        )
+
+    def test_online_submission_url_default_is_empty(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.online_submission_url, "")


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona campo URL de submissão de manuscritos (online_submission_url) no periódico. É um link disponibilizado na home page do periódico.

#### Onde a revisão poderia começar?
Em `documentstore/domain.py`, a property `Journal.online_submission_url`

#### Como este poderia ser testado manualmente?
Criar uma instância de `Journal` e utilize a propriedade `online_submission_url`.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#35 

### Referências
N/A
