### PR TITLE
 #43 Incluir campo para instituição responsável pelo periodico no domain

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -684,3 +684,23 @@ class Journal:
                 "cannot set metrics with value " '"%s": value must be dict' % value
             ) from None
         self.manifest = BundleManifest.set_metadata(self._manifest, "metrics", value)
+
+    @property
+    def institution_responsible_for(self):
+        return BundleManifest.get_metadata(
+            self.manifest, "institution_responsible_for", ()
+        )
+
+    @institution_responsible_for.setter
+    def institution_responsible_for(self, value: tuple):
+        try:
+            value = tuple(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                "cannot set institution_responsible_for with value "
+                '"%s": value must be tuple' % repr(value)
+            ) from None
+
+        self.manifest = BundleManifest.set_metadata(
+            self.manifest, "institution_responsible_for", value
+        )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1090,3 +1090,35 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "metrics",
             "metrics-invalid",
         )
+
+    def test_institution_responsible_for_is_empty_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.institution_responsible_for, ())
+
+    def test_set_institution_responsible_for(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.institution_responsible_for = ("Usp", "Scielo")
+
+        self.assertEqual(journal.institution_responsible_for, ("Usp", "Scielo"))
+        self.assertEqual(
+            journal.manifest["metadata"]["institution_responsible_for"][-1],
+            ("2018-08-05T22:33:49.795151Z", ("Usp", "Scielo")),
+        )
+
+    def test_set_institution_responsible_for_content_raises_type_error(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        invalid = 1
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set institution_responsible_for with value "
+            '"%s": value must be tuple' % invalid,
+            setattr,
+            journal,
+            "institution_responsible_for",
+            invalid,
+        )
+
+    def test_institution_responsible_for_content_value_for_string(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.institution_responsible_for = ["USP", "SCIELO"]
+        self.assertEqual(journal.institution_responsible_for, ("USP", "SCIELO"))


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o campo de instituição responsável pelo periódico no domain journal 

#### Onde a revisão poderia começar?
Verificando os arquivos `documentstore/domain.py`

#### Como este poderia ser testado manualmente?
Executar o comando `python setup.py test``

#### Quais são tickets relevantes?
#43 