### PR TITLE
Altera as chamadas do get_metadata dos Bundles

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -425,7 +425,7 @@ class DocumentsBundle:
 
     @property
     def publication_year(self):
-        return BundleManifest.get_metadata(self._manifest, "publication_year")
+        return BundleManifest.get_metadata(self.manifest, "publication_year")
 
     @publication_year.setter
     def publication_year(self, value: Union[str, int]):
@@ -441,7 +441,7 @@ class DocumentsBundle:
 
     @property
     def volume(self):
-        return BundleManifest.get_metadata(self._manifest, "volume")
+        return BundleManifest.get_metadata(self.manifest, "volume")
 
     @volume.setter
     def volume(self, value: Union[str, int]):
@@ -450,7 +450,7 @@ class DocumentsBundle:
 
     @property
     def number(self):
-        return BundleManifest.get_metadata(self._manifest, "number")
+        return BundleManifest.get_metadata(self.manifest, "number")
 
     @number.setter
     def number(self, value: Union[str, int]):
@@ -459,7 +459,7 @@ class DocumentsBundle:
 
     @property
     def supplement(self):
-        return BundleManifest.get_metadata(self._manifest, "supplement")
+        return BundleManifest.get_metadata(self.manifest, "supplement")
 
     @supplement.setter
     def supplement(self, value: Union[str, int]):
@@ -511,7 +511,7 @@ class Journal:
 
     @property
     def mission(self):
-        return BundleManifest.get_metadata(self._manifest, "mission", {})
+        return BundleManifest.get_metadata(self.manifest, "mission", {})
 
     @mission.setter
     def mission(self, value: dict):
@@ -525,7 +525,7 @@ class Journal:
 
     @property
     def title(self):
-        return BundleManifest.get_metadata(self._manifest, "title")
+        return BundleManifest.get_metadata(self.manifest, "title")
 
     @title.setter
     def title(self, value: str):
@@ -534,7 +534,7 @@ class Journal:
 
     @property
     def title_iso(self):
-        return BundleManifest.get_metadata(self._manifest, "title_iso")
+        return BundleManifest.get_metadata(self.manifest, "title_iso")
 
     @title_iso.setter
     def title_iso(self, value: str):
@@ -543,7 +543,7 @@ class Journal:
 
     @property
     def short_title(self):
-        return BundleManifest.get_metadata(self._manifest, "short_title")
+        return BundleManifest.get_metadata(self.manifest, "short_title")
 
     @short_title.setter
     def short_title(self, value: str):
@@ -554,7 +554,7 @@ class Journal:
 
     @property
     def title_slug(self):
-        return BundleManifest.get_metadata(self._manifest, "title_slug")
+        return BundleManifest.get_metadata(self.manifest, "title_slug")
 
     @title_slug.setter
     def title_slug(self, value: str):
@@ -565,7 +565,7 @@ class Journal:
 
     @property
     def acronym(self):
-        return BundleManifest.get_metadata(self._manifest, "acronym")
+        return BundleManifest.get_metadata(self.manifest, "acronym")
 
     @acronym.setter
     def acronym(self, value: str):
@@ -574,7 +574,7 @@ class Journal:
 
     @property
     def scielo_issn(self):
-        return BundleManifest.get_metadata(self._manifest, "scielo_issn")
+        return BundleManifest.get_metadata(self.manifest, "scielo_issn")
 
     @scielo_issn.setter
     def scielo_issn(self, value: str):
@@ -585,7 +585,7 @@ class Journal:
 
     @property
     def print_issn(self):
-        return BundleManifest.get_metadata(self._manifest, "print_issn")
+        return BundleManifest.get_metadata(self.manifest, "print_issn")
 
     @print_issn.setter
     def print_issn(self, value: str):
@@ -596,7 +596,7 @@ class Journal:
 
     @property
     def electronic_issn(self):
-        return BundleManifest.get_metadata(self._manifest, "electronic_issn")
+        return BundleManifest.get_metadata(self.manifest, "electronic_issn")
 
     @electronic_issn.setter
     def electronic_issn(self, value: str):
@@ -607,7 +607,7 @@ class Journal:
 
     @property
     def current_status(self):
-        return BundleManifest.get_metadata(self._manifest, "current_status")
+        return BundleManifest.get_metadata(self.manifest, "current_status")
 
     @current_status.setter
     def current_status(self, value: str):
@@ -618,7 +618,7 @@ class Journal:
 
     @property
     def subject_areas(self):
-        return BundleManifest.get_metadata(self._manifest, "subject_areas")
+        return BundleManifest.get_metadata(self.manifest, "subject_areas")
 
     @subject_areas.setter
     def subject_areas(self, value: tuple):
@@ -641,7 +641,7 @@ class Journal:
 
     @property
     def sponsors(self) -> Tuple[dict]:
-        return BundleManifest.get_metadata(self._manifest, "sponsors")
+        return BundleManifest.get_metadata(self.manifest, "sponsors")
 
     @sponsors.setter
     def sponsors(self, value: Tuple[dict]) -> None:
@@ -654,7 +654,7 @@ class Journal:
 
     @property
     def metrics(self):
-        return BundleManifest.get_metadata(self._manifest, "metrics", {})
+        return BundleManifest.get_metadata(self.manifest, "metrics", {})
 
     @metrics.setter
     def metrics(self, value: dict):


### PR DESCRIPTION
#### O que esse PR faz?
Altera as chamadas do `get_metadata` dos Bundles para que o estado de `BundleManifest.metadata` não seja alterado na mudança de valores de dados.

#### Onde a revisão poderia começar?
Em `documentstore/domain.py`, nos getters de `DocumentsBundle` e `Journal`.

#### Como este poderia ser testado manualmente?
Seguir o exemplo dado no ticket #33, que descreve o comportamento esperado. 

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#33 

### Referências
N/A
