### PR TITLE
[Journal] Remover Campos `unpublish_reason` e `is_public`

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -628,14 +628,6 @@ class Journal:
         )
 
     @property
-    def is_public(self):
-        return BundleManifest.get_metadata(self._manifest, "is_public", True)
-
-    @is_public.setter
-    def is_public(self, value: bool):
-        self.manifest = BundleManifest.set_metadata(self._manifest, "is_public", value)
-
-    @property
     def subject_areas(self):
         return BundleManifest.get_metadata(self._manifest, "subject_areas")
 

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -617,17 +617,6 @@ class Journal:
         )
 
     @property
-    def unpublish_reason(self):
-        return BundleManifest.get_metadata(self._manifest, "unpublish_reason")
-
-    @unpublish_reason.setter
-    def unpublish_reason(self, value: str):
-        _value = str(value)
-        self.manifest = BundleManifest.set_metadata(
-            self._manifest, "unpublish_reason", _value
-        )
-
-    @property
     def subject_areas(self):
         return BundleManifest.get_metadata(self._manifest, "subject_areas")
 

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -832,19 +832,6 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             [("2018-08-05T22:33:49.795151Z", "current")],
         )
 
-    def test_unpublish_reason_is_empty_str(self):
-        journal = domain.Journal(id="0034-8910-rsp-48-2")
-        self.assertEqual(journal.unpublish_reason, "")
-
-    def test_set_unpublish_reason(self):
-        journal = domain.Journal(id="0034-8910-rsp-48-2")
-        journal.unpublish_reason = "not-open-access"
-        self.assertEqual(journal.unpublish_reason, "not-open-access")
-        self.assertEqual(
-            journal.manifest["metadata"]["unpublish_reason"],
-            [("2018-08-05T22:33:49.795151Z", "not-open-access")],
-        )
-
     def test_get_created(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
         self.assertEqual(journal.created(), "2018-08-05T22:33:49.795151Z")

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -845,28 +845,6 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             [("2018-08-05T22:33:49.795151Z", "not-open-access")],
         )
 
-    def test_is_public_is_default_true(self):
-        journal = domain.Journal(id="0034-8910-rsp-48-2")
-        self.assertTrue(journal.is_public)
-
-    def test_set_is_public(self):
-        journal = domain.Journal(id="0034-8910-rsp-48-2")
-        journal.is_public = True
-        self.assertTrue(journal.is_public)
-        self.assertEqual(
-            journal.manifest["metadata"]["is_public"],
-            [("2018-08-05T22:33:49.795151Z", True)],
-        )
-
-    def test_set_is_public_to_false(self):
-        journal = domain.Journal(id="0034-8910-rsp-48-2")
-        journal.is_public = False
-        self.assertFalse(journal.is_public)
-        self.assertEqual(
-            journal.manifest["metadata"]["is_public"],
-            [("2018-08-05T22:33:49.795151Z", False)],
-        )
-
     def test_get_created(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
         self.assertEqual(journal.created(), "2018-08-05T22:33:49.795151Z")


### PR DESCRIPTION
#### O que esse PR faz?
Remover o campo `unpublish_reason` e `is_public`, esses campos são  utilizado para saber se o periodico deve ser mostrado no site. Ele so foi implementado devido ao lote de campo do ticker #8

#### Onde a revisão poderia começar?
Verificando os arquivos `documentstore/domain.py`

#### Como este poderia ser testado manualmente?
pelo comando `python setup.py`

#### Quais são tickets relevantes?
#45 e #8 