### PR TITLE
[Domain][Journal] Incluir interface para acessar todos os status

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -364,6 +364,13 @@ class BundleManifest:
             return default
 
     @staticmethod
+    def get_metadata_all(bundle: dict, name: str) -> Any:
+        try:
+            return bundle["metadata"].get(name, [])
+        except IndexError:
+            return default
+
+    @staticmethod
     def add_item(bundle: dict, item: str, now: Callable[[], str] = utcnow) -> dict:
         if item in bundle["items"]:
             raise exceptions.AlreadyExists(
@@ -606,15 +613,18 @@ class Journal:
         )
 
     @property
-    def current_status(self):
-        return BundleManifest.get_metadata(self.manifest, "current_status")
+    def status(self):
+        return BundleManifest.get_metadata(self.manifest, "status")
 
-    @current_status.setter
-    def current_status(self, value: str):
-        _value = str(value)
-        self.manifest = BundleManifest.set_metadata(
-            self._manifest, "current_status", _value
-        )
+    @status.setter
+    def status(self, value: dict):
+        try:
+            value = dict(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                "cannot set status with value " '"%s": value must be dict' % repr(value)
+            ) from None
+        self.manifest = BundleManifest.set_metadata(self._manifest, "status", value)
 
     @property
     def subject_areas(self):
@@ -714,3 +724,7 @@ class Journal:
         self.manifest = BundleManifest.set_metadata(
             self._manifest, "online_submission_url", _value
         )
+
+    @property
+    def status_history(self):
+        return BundleManifest.get_metadata_all(self.manifest, "status")

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -299,6 +299,19 @@ class BundleManifestTest(UnittestMixin, unittest.TestCase):
             "2018",
         )
 
+    def test_get_metadata_all(self):
+        documents_bundle = new_bundle("0034-8910-rsp-48-2")
+        documents_bundle = domain.BundleManifest.set_metadata(
+            documents_bundle, "publication_year", "2018"
+        )
+        documents_bundle = domain.BundleManifest.set_metadata(
+            documents_bundle, "publication_year", "2019"
+        )
+        items = domain.BundleManifest.get_metadata_all(
+            documents_bundle, "publication_year"
+        )
+        self.assertEqual([data[1] for data in items], ["2018", "2019"])
+
     def test_get_metadata_always_returns_latest(self):
         documents_bundle = new_bundle("0034-8910-rsp-48-2")
         documents_bundle = domain.BundleManifest.set_metadata(
@@ -819,17 +832,17 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             [("2018-08-05T22:33:49.795151Z", "1809-4392")],
         )
 
-    def test_current_status_is_empty_str(self):
+    def test_status_is_empty_str(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
-        self.assertEqual(journal.current_status, "")
+        self.assertEqual(journal.status, "")
 
-    def test_set_current_status(self):
+    def test_set_status(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
-        journal.current_status = "current"
-        self.assertEqual(journal.current_status, "current")
+        journal.status = {"status": "current"}
+        self.assertEqual(journal.status, {"status": "current"})
         self.assertEqual(
-            journal.manifest["metadata"]["current_status"],
-            [("2018-08-05T22:33:49.795151Z", "current")],
+            journal.manifest["metadata"]["status"],
+            [("2018-08-05T22:33:49.795151Z", {"status": "current"})],
         )
 
     def test_get_created(self):
@@ -1104,7 +1117,6 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         journal = domain.Journal(id="0234-8410-bjmbr-587-90")
 
         class Fibonacci:
-
             def __init__(self, maximo=1000000):
                 self.current, self.p_element = 0, 1
                 self.maximo = maximo
@@ -1118,7 +1130,10 @@ class JournalTest(UnittestMixin, unittest.TestCase):
 
                 ret = self.current
 
-                self.current, self.p_element = self.p_element, self.current + self.p_element
+                self.current, self.p_element = (
+                    self.p_element,
+                    self.current + self.p_element,
+                )
 
                 return str(ret)
 
@@ -1127,7 +1142,7 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         journal.subject_categories = fib_obj
         self.assertEqual(
             journal.manifest["metadata"]["subject_categories"],
-            [("2018-08-05T22:33:49.795151Z", ['0', '1', '1', '2', '3', '5', '8'])],
+            [("2018-08-05T22:33:49.795151Z", ["0", "1", "1", "2", "3", "5", "8"])],
         )
 
     def test_institution_responsible_for_is_empty_str(self):
@@ -1175,3 +1190,21 @@ class JournalTest(UnittestMixin, unittest.TestCase):
     def test_online_submission_url_default_is_empty(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
         self.assertEqual(journal.online_submission_url, "")
+
+    def test_status_history(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.status = {"status": "CURRENT"}
+        journal.status = {"status": "SUSPENDED", "notes": "motivo"}
+        journal.status = {"status": "CEASED"}
+        self.assertEqual(
+            [item[0] for item in journal.status_history],
+            sorted([item[0] for item in journal.status_history]),
+        )
+        self.assertEqual(
+            [item[1] for item in journal.status_history],
+            [
+                {"status": "CURRENT"},
+                {"status": "SUSPENDED", "notes": "motivo"},
+                {"status": "CEASED"},
+            ],
+        )


### PR DESCRIPTION
#### O que esse PR faz?
 - Troca current_status por status.
 - Cria status_history que retorna todos os status
Foi necessário criar um novo atributo em DocumentsBundleManifest.get_metadata_all para retornar todas a versões de status e a data correspondente.

#### Onde a revisão poderia começar?
tests/test_domain.py

#### Como este poderia ser testado manualmente?
Executando python setup.py test

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#26 

### Referências
N/A