### PR TITLE
Adiciona serviço de criação de periódico

### DIFF
--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -29,7 +29,11 @@ class Session(interfaces.Session):
 
     @property
     def documents_bundles(self):
-        return None
+        return DocumentsBundleStore(self._collection)
+
+    @property
+    def journals(self):
+        return JournalStore(self._collection)
 
 
 class BaseStore(interfaces.DataStore):
@@ -73,3 +77,7 @@ class DocumentStore(BaseStore):
 
 class DocumentsBundleStore(BaseStore):
     DomainClass = domain.DocumentsBundle
+
+
+class JournalStore(BaseStore):
+    DomainClass = domain.Journal

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -1,11 +1,11 @@
-from typing import Callable, Dict
+from typing import Callable, Dict, List, Any
 import difflib
 from io import BytesIO
 
 from clea import join as clea_join, core as clea_core
 
 from .interfaces import Session
-from .domain import Document, DocumentsBundle
+from .domain import Document, DocumentsBundle, Journal
 
 __all__ = ["get_handlers"]
 
@@ -244,6 +244,15 @@ class InsertDocumentToDocumentsBundle(CommandHandler):
         session.documents_bundles.update(_bundle)
 
 
+class CreateJournal(CommandHandler):
+    def __call__(self, id: str, metadata: Dict[str, Any] = None) -> None:
+        session = self.Session()
+        _journal = Journal(id)
+        for name, value in (metadata or {}).items():
+            setattr(_journal, name, value)
+        return session.journals.add(_journal)
+
+
 def get_handlers(Session: Callable[[], Session]) -> dict:
     return {
         "register_document": RegisterDocument(Session),
@@ -259,4 +268,5 @@ def get_handlers(Session: Callable[[], Session]) -> dict:
         "update_documents_bundle_metadata": UpdateDocumentsBundleMetadata(Session),
         "add_document_to_documents_bundle": AddDocumentToDocumentsBundle(Session),
         "insert_document_to_documents_bundle": InsertDocumentToDocumentsBundle(Session),
+        "create_journal": CreateJournal(Session),
     }

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -5,6 +5,7 @@ class Session(interfaces.Session):
     def __init__(self):
         self._documents = InMemoryDocumentStore()
         self._documents_bundles = InMemoryDocumentsBundleStore()
+        self._journals = InMemoryJournalStore()
 
     @property
     def documents(self):
@@ -13,6 +14,10 @@ class Session(interfaces.Session):
     @property
     def documents_bundles(self):
         return self._documents_bundles
+
+    @property
+    def journals(self):
+        return self._journals
 
 
 class InMemoryDataStore(interfaces.DataStore):
@@ -45,6 +50,10 @@ class InMemoryDocumentStore(InMemoryDataStore):
 
 class InMemoryDocumentsBundleStore(InMemoryDataStore):
     DomainClass = domain.DocumentsBundle
+
+
+class InMemoryJournalStore(InMemoryDataStore):
+    DomainClass = domain.Journal
 
 
 def document_registry_data_fixture(prefix=""):

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -4,12 +4,23 @@ from unittest.mock import Mock
 from documentstore import adapters, domain, exceptions
 
 
+class MongoClientStub:
+    def collection(self):
+        return None
+
+
 class StoreTestMixin:
     def setUp(self):
         self.DBCollectionMock = Mock()
         self.DBCollectionMock.insert_one = Mock()
         self.DBCollectionMock.find_one = Mock()
         self.DBCollectionMock.replace_one = Mock()
+
+    def test_session(self):
+        session = adapters.Session(MongoClientStub())
+        self.assertIsInstance(session.documents, adapters.DocumentStore)
+        self.assertIsInstance(session.documents_bundles, adapters.DocumentsBundleStore)
+        self.assertIsInstance(session.journals, adapters.JournalStore)
 
     def test_add(self):
         store = self.Adapter(self.DBCollectionMock)
@@ -93,3 +104,9 @@ class DocumentsStoreTest(StoreTestMixin, unittest.TestCase):
 
     Adapter = adapters.DocumentStore
     DomainClass = domain.Document
+
+
+class JournalStoreTest(StoreTestMixin, unittest.TestCase):
+
+    Adapter = adapters.JournalStore
+    DomainClass = domain.Journal

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -250,3 +250,31 @@ class InsertDocumentToDocumentsBundleTest(unittest.TestCase):
             index=1,
             doc="/document/1",
         )
+
+
+class CreateJournalTest(unittest.TestCase):
+    def setUp(self):
+        self.services = make_services()
+        self.command = self.services.get("create_journal")
+
+    def test_command_interface(self):
+        self.assertIsNotNone(self.command)
+        self.assertTrue(callable(self.command))
+
+    def test_command_success(self):
+        self.assertIsNone(self.command(id="xpto"))
+
+    def test_command_with_metadata_success(self):
+        self.assertIsNone(
+            self.command(
+                id="xpto",
+                metadata={
+                    "title": "Journal Title",
+                    "mission": {"pt": "Missão do Periódico", "en": "Journal Mission"},
+                },
+            )
+        )
+
+    def test_command_raises_exception_if_already_exists(self):
+        self.command(id="xpto")
+        self.assertRaises(exceptions.AlreadyExists, self.command, id="xpto")


### PR DESCRIPTION
#### O que esse PR faz?
- Adiciona CreateJournal em services para permitir que sejam criados periódicos no kernel
- Atualiza os adapters com a implementação do Store para Journal

#### Onde a revisão poderia começar?
Em `documentstore/services.py`, no comando `CreateJournal`

#### Como este poderia ser testado manualmente?
Dada uma Session, o seguinte código deve funcionar:
```
>>> command = services.CreateJournal(Session)
>>> command(id="xpto")
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#49 

### Referências
N/A