### PR TITLE
Tk38 - Adiciona o campo ``next_journal``.

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -425,7 +425,6 @@ class DocumentsBundle:
 
     @property
     def publication_year(self):
-        return BundleManifest.get_metadata(self._manifest, "publication_year")
         return BundleManifest.get_metadata(self.manifest, "publication_year")
 
     @publication_year.setter

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -685,3 +685,22 @@ class Journal:
         self.manifest = BundleManifest.set_metadata(
             self.manifest, "institution_responsible_for", value
         )
+
+    @property
+    def next_journal(self):
+        return BundleManifest.get_metadata(
+            self.manifest, "next_journal", {}
+        )
+
+    @next_journal.setter
+    def next_journal(self, value: dict):
+        try:
+            value = dict(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                "cannot set next_journal with value "
+                '"%s": value must be dict' % repr(value)
+            ) from None
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "next_journal", value
+        )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1189,7 +1189,7 @@ class JournalTest(UnittestMixin, unittest.TestCase):
 
     def test_set_str_to_next_journal_should_raise_type_error(self):
         journal = domain.Journal(id="0034-8910-MR")
-        invalid = 'name'
+        invalid = "name"
         self._assert_raises_with_message(
             TypeError,
             "cannot set next_journal with value "
@@ -1215,7 +1215,7 @@ class JournalTest(UnittestMixin, unittest.TestCase):
 
     def test_set_tuple_to_next_journal_should_raise_type_error(self):
         journal = domain.Journal(id="0034-8910-MR")
-        invalid = ('item 1', 'item 2')
+        invalid = ("item 1", "item 2")
         self._assert_raises_with_message(
             TypeError,
             "cannot set next_journal with value "

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1087,3 +1087,61 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
         journal.institution_responsible_for = ["USP", "SCIELO"]
         self.assertEqual(journal.institution_responsible_for, ("USP", "SCIELO"))
+
+    def test_set_next_journal(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        next_journal = {"title": "Materials Research", "id": "journal/0034-8910"}
+        journal.next_journal = next_journal
+        self.assertEqual(
+            journal.manifest["metadata"]["next_journal"],
+            [("2018-08-05T22:33:49.795151Z", next_journal)],
+        )
+
+    def test_set_str_to_next_journal_should_raise_type_error(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        invalid = 'name'
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set next_journal with value "
+            '"%s": value must be dict' % repr(invalid),
+            setattr,
+            journal,
+            "next_journal",
+            invalid,
+        )
+
+    def test_set_int_to_next_journal_should_raise_type_error(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        invalid = 10
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set next_journal with value "
+            '"%s": value must be dict' % repr(invalid),
+            setattr,
+            journal,
+            "next_journal",
+            invalid,
+        )
+
+    def test_set_tuple_to_next_journal_should_raise_type_error(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        invalid = ('item 1', 'item 2')
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set next_journal with value "
+            '"%s": value must be dict' % repr(invalid),
+            setattr,
+            journal,
+            "next_journal",
+            invalid,
+        )
+
+    def test_next_journal_return_empty_dict(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        self.assertEqual(journal.next_journal, {})
+
+    def test_next_journal_return_raise_key_error_metadata(self):
+        journal = domain.Journal(id="0034-8910-MR")
+
+        with self.assertRaises(KeyError):
+            journal.manifest["metadata"]["next_journal"]


### PR DESCRIPTION
#### O que esse PR faz?

Inclui o campo **next_journal** no modelo de Journal.

#### Onde a revisão poderia começar?

No arquivo documentstore/domain.py:Journal:next_journal

#### Como este poderia ser testado manualmente?

```python setup.py``` test ou com interpretador interativo do python

#### Algum cenário de contexto que queira dar?

Não há 

### Screenshots

Não há 

#### Quais são tickets relevantes?

Refere-se ao ticket #38 

### Referências

Não há
