### PR TITLE
Adiciona Journal.add_documents_bundle()

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -788,3 +788,6 @@ class Journal:
             ) from None
 
         self.manifest = BundleManifest.set_metadata(self._manifest, "contact", value)
+
+    def add_documents_bundle(self, bundle: str):
+        self.manifest = BundleManifest.add_item(self._manifest, bundle)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1330,3 +1330,19 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "contact",
             "contact-invalid",
         )
+
+    def test_add_documents_bundle(self):
+        journal = domain.Journal(id="0034-8910-rsp")
+        journal.add_documents_bundle("/bundles/0034-8910-rsp-48-2")
+        self.assertIn("/bundles/0034-8910-rsp-48-2", journal.manifest["items"])
+
+    def test_add_documents_bundle_raises_exception_if_item_already_exists(self):
+        journal = domain.Journal(id="0034-8910-rsp")
+        journal.add_documents_bundle("/bundles/0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            exceptions.AlreadyExists,
+            'cannot add item "/bundles/0034-8910-rsp-48-2" in bundle: '
+            "the item already exists",
+            journal.add_documents_bundle,
+            "/bundles/0034-8910-rsp-48-2",
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona método `add_documents_bundle()` a `Journal`, necessário para compor o periódico com um `DocumentsBundle` através de adição da uri ao final da lista.

#### Onde a revisão poderia começar?
Em `documentstore/domain.py`, no método `Journal.add_documents_bundle()`.

#### Como este poderia ser testado manualmente?
Ao criar uma instância de `Journal`, deve ser possível executar `journal.add_documents_bundle(<uri de DocumentsBundle>)` e esta ser adicionada à lista de `items` no JournalManifest.

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#55

### Referências
Nenhuma.