### PR TITLE
Sistema de eventos e testes para interfaces.Session

### DIFF
--- a/documentstore/interfaces.py
+++ b/documentstore/interfaces.py
@@ -1,5 +1,9 @@
 import abc
 import functools
+import logging
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class DataStore(abc.ABC):
@@ -21,6 +25,9 @@ class DataStore(abc.ABC):
 
 class Session(abc.ABC):
     """Concentra os pontos de acesso aos repositórios de dados.
+
+    Classes `Session` implementam o padrão Observable com a finalidade de 
+    suportar um sistema de eventos.
     """
 
     @classmethod
@@ -40,3 +47,27 @@ class Session(abc.ABC):
         """Ponto de acesso à instância de ``DataStore``.
         """
         pass
+
+    def observe(self, event, callback):
+        """Registra `callback` para ser executado na ocorrência de `event`.
+        """
+        observers = getattr(self, "_observers", None)
+        if observers is None:
+            self._observers = {}
+            observers = self._observers
+
+        observers.setdefault(event, []).append(callback)
+
+    def notify(self, event, data):
+        """Notifica a ocorrência de `event`.
+        """
+        observers = getattr(self, "_observers", {})
+        for callback in observers.get(event, []):
+            try:
+                callback(data, self)
+            except:
+                LOGGER.exception(
+                    'cannot run callback "%s" in response to event "%s"',
+                    repr(callback),
+                    event,
+                )

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,12 +1,8 @@
 import unittest
 from unittest.mock import Mock
 
-from documentstore import adapters, domain, exceptions
-
-
-class MongoClientStub:
-    def collection(self):
-        return None
+from documentstore import adapters, domain, exceptions, interfaces
+from . import apptesting
 
 
 class StoreTestMixin:
@@ -15,12 +11,6 @@ class StoreTestMixin:
         self.DBCollectionMock.insert_one = Mock()
         self.DBCollectionMock.find_one = Mock()
         self.DBCollectionMock.replace_one = Mock()
-
-    def test_session(self):
-        session = adapters.Session(MongoClientStub())
-        self.assertIsInstance(session.documents, adapters.DocumentStore)
-        self.assertIsInstance(session.documents_bundles, adapters.DocumentsBundleStore)
-        self.assertIsInstance(session.journals, adapters.JournalStore)
 
     def test_add(self):
         store = self.Adapter(self.DBCollectionMock)
@@ -110,3 +100,39 @@ class JournalStoreTest(StoreTestMixin, unittest.TestCase):
 
     Adapter = adapters.JournalStore
     DomainClass = domain.Journal
+
+
+class SessionTestMixin:
+    """Testa a interface de `interfaces.Session`. Qualquer classe que implementar
+    a interface mencionada deverá acompanhar um conjunto de testes que herdam
+    deste mixin, conforme o exemplo:
+
+        class AppTestingSessionTests(SessionTestMixin, inittest.TestCase):
+            Session = apptesting.Session
+    """
+
+    def test_documents_attribute(self):
+        session = self.Session()
+        self.assertIsInstance(session.documents, interfaces.DataStore)
+
+    def test_documents_bundles_attribute(self):
+        session = self.Session()
+        self.assertIsInstance(session.documents_bundles, interfaces.DataStore)
+
+    def test_journals_attribute(self):
+        session = self.Session()
+        self.assertIsInstance(session.journals, interfaces.DataStore)
+
+
+class AppTestingSessionTests(SessionTestMixin, unittest.TestCase):
+    Session = apptesting.Session
+
+
+class MongoClientStub:
+    def collection(self):
+        return None
+
+
+class SessionTests(SessionTestMixin, unittest.TestCase):
+    def Session(self):
+        return adapters.Session(MongoClientStub())


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request contém 2 mudanças:

  1. Cria teste para interfaces.Session e os aplica nas classes que a implementam;
  2. Adiciona sistema de eventos por meio da implementação do _design pattern Observer_, na classe _Session_.

#### Onde a revisão poderia começar?

Penso que o módulo `documentstore.services` seja um bom ponto de partida. Lá você poderá ver quais eventos foram implementados e seus locais de emissão.

#### Como este poderia ser testado manualmente?

python setup.py test

#### Algum cenário de contexto que queira dar?

O sistema de eventos é parte da infraestrutura para a implementação da API de mudanças.

### Screenshots

#### Quais são tickets relevantes?

#50 e #53

(fixes #53)

### Referências
