### PR TITLE
Adiciona add_issue, insert_issue e remove_issue ao Journal

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -788,3 +788,12 @@ class Journal:
             ) from None
 
         self.manifest = BundleManifest.set_metadata(self._manifest, "contact", value)
+
+    def add_issue(self, issue: str) -> None:
+        self.manifest = BundleManifest.add_item(self._manifest, issue)
+
+    def insert_issue(self, index: int, issue: str) -> None:
+        self.manifest = BundleManifest.insert_item(self._manifest, index, issue)
+
+    def remove_issue(self, issue: str) -> None:
+        self.manifest = BundleManifest.remove_item(self._manifest, issue)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona os métodos `add_issue`, `insert_issue` e `remove_issue` ao `Journal` , para que seja possível adicionar, inserir e remover um fascículo que compõe um periódico.

#### Onde a revisão poderia começar?
Em `documentstore/domain.py`, no método `Journal.add_issue`.

#### Como este poderia ser testado manualmente?
Ao criar uma instância de `Journal`, deve ser possível:
- usar o `add_issue` para adicionar um fascículo ao final da lista de items.
- usar o `insert_issue` para inserir um fascículo na posição informada na lista de items.
- usar o `remove_issue` para remover um fascículo da lista de items.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
Fix #68 

### Referências
Nenhuma.
