### PR TITLE
Adiciona set, get e remove component ao BundleManifest

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -407,6 +407,32 @@ class BundleManifest:
         _items_bundle["updated"] = now()
         return _items_bundle
 
+    @staticmethod
+    def set_component(
+        components_bundle: dict, name: str, value: Any, now: Callable[[], str] = utcnow
+    ) -> None:
+        _components_bundle = deepcopy(components_bundle)
+        _components_bundle[name] = value
+        _components_bundle["updated"] = now()
+        return _components_bundle
+
+    @staticmethod
+    def get_component(components_bundle: dict, name: str, default: str = "") -> Any:
+        return components_bundle.get(name, default)
+
+    @staticmethod
+    def remove_component(components_bundle: dict, name: str) -> dict:
+        _components_bundle = deepcopy(components_bundle)
+        try:
+            del _components_bundle[name]
+        except KeyError:
+            raise exceptions.DoesNotExist(
+                f'cannot remove component "{name}" from bundle: '
+                "the component does not exist"
+            ) from None
+        else:
+            return _components_bundle
+
 
 class DocumentsBundle:
     """

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -340,6 +340,75 @@ class BundleManifestTest(UnittestMixin, unittest.TestCase):
             "2019",
         )
 
+    def test_set_component(self):
+        bundle = new_bundle("0034-8910-rsp")
+        bundle = domain.BundleManifest.set_component(
+            bundle, "component-1", "component-1"
+        )
+        self.assertEqual(bundle["component-1"], "component-1")
+
+    def test_set_component_updates_last_modification_date(self):
+        bundle = new_bundle("0034-8910-rsp-48-2")
+        current_updated = bundle["updated"]
+        bundle = domain.BundleManifest.set_component(
+            bundle, "component-1", "component-1"
+        )
+        self.assertTrue(current_updated < bundle["updated"])
+
+    def test_set_component_to_preexisting_set(self):
+        bundle = new_bundle("0034-8910-rsp-48-2")
+        bundle = domain.BundleManifest.set_component(
+            bundle, "component-1", "component-1"
+        )
+        bundle = domain.BundleManifest.set_component(
+            bundle, "component-1", "component-123"
+        )
+        self.assertEqual(bundle["component-1"], "component-123")
+
+    def test_get_component_returns_empty_str(self):
+        bundle = new_bundle("0034-8910-rsp")
+        self.assertEqual(
+            domain.BundleManifest.get_component(bundle, "component-1", ""), ""
+        )
+
+    def test_get_component_returns_given_default_value(self):
+        bundle = new_bundle("0034-8910-rsp")
+        self.assertEqual(
+            domain.BundleManifest.get_component(bundle, "component-1", [1, 2, 3]),
+            [1, 2, 3],
+        )
+
+    def test_get_component_returns_component_set(self):
+        bundle = new_bundle("0034-8910-rsp")
+        bundle = domain.BundleManifest.set_component(
+            bundle, "component-1", "component-123"
+        )
+        self.assertEqual(
+            domain.BundleManifest.get_component(bundle, "component-1", ""),
+            "component-123",
+        )
+
+    def test_remove_component(self):
+        bundle = new_bundle("0034-8910-rsp")
+        bundle = domain.BundleManifest.set_component(
+            bundle, "component-1", "component-123"
+        )
+        _bundle = domain.BundleManifest.remove_component(bundle, "component-1")
+        self.assertEqual(
+            domain.BundleManifest.get_component(_bundle, "component-1"), ""
+        )
+
+    def test_remove_component_raises_exception_if_does_not_exist(self):
+        bundle = new_bundle("0034-8910-rsp")
+        self._assert_raises_with_message(
+            exceptions.DoesNotExist,
+            'cannot remove component "component-1" from bundle: '
+            "the component does not exist",
+            domain.BundleManifest.remove_component,
+            bundle,
+            "component-1",
+        )
+
     def test_add_item(self):
         documents_bundle = new_bundle("0034-8910-rsp-48-2")
         current_updated = documents_bundle["updated"]


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona `set_component`, `get_component` e `remove_component` ao BundleManifest, interface genérica para compor o manifesto.

#### Onde a revisão poderia começar?
Em `documentstore/domain.py`, o static method `BundleManifest.set_component`.

#### Como este poderia ser testado manualmente?
Com os testes em `tests/test_domain`, agrupados em `BundleManifestTest`, rodar `python setup.py test`

#### Algum cenário de contexto que queira dar?
Fez-se necessário compor o Journal com componentes que não são metadados e não são issues (items).

### Screenshots
N/A

#### Quais são tickets relevantes?
Fix #73 

### Referências
Nenhuma.
