### PR TITLE
Restringe o registro de callbacks para eventos.

### DIFF
--- a/documentstore/interfaces.py
+++ b/documentstore/interfaces.py
@@ -56,7 +56,7 @@ class Session(abc.ABC):
             self._observers = {}
             observers = self._observers
 
-        observers.setdefault(event, []).append(callback)
+        observers.setdefault(event, set()).add(callback)
 
     def notify(self, event, data):
         """Notifica a ocorrência de `event`.

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -134,6 +134,16 @@ class SessionTestMixin:
         session.notify("test_event", "foo")
         callback.assert_called_once_with("foo", session)
 
+    def test_observe_ignores_duplicated_event_callback_pairs(self):
+        """Serão ignorados os registros duplicados de pares evento-callback. 
+        """
+        callback = Mock()
+        session = self.Session()
+        session.observe("test_event", callback)
+        session.observe("test_event", callback)
+        session.notify("test_event", "foo")
+        callback.assert_called_once_with("foo", session)
+
     def test_notify_doesnt_propagate_exceptions(self):
         import logging
 


### PR DESCRIPTION
#### O que esse PR faz?

A implementação passa a não mais permitir o registro repetido de pares
evento-callback. A justificativa para tal restrição é que, além de não fazer
o menor sentido registrar o mesmo callback mais de uma vez para o mesmo
evento, essa restrição pode evitar erros difíceis de rastrear.

#### Onde a revisão poderia começar?
 tests/test_adapters.py

#### Como este poderia ser testado manualmente?
python setup.py test

#### Algum cenário de contexto que queira dar?

Este cenário se manifestou enquanto @jamilatta e eu trabalhávamos na API de mudanças (ainda em progresso). 

### Screenshots

#### Quais são tickets relevantes?

### Referências
