### PR TITLE
Add changes api

### DIFF
--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -90,7 +90,7 @@ class ChangesStore(interfaces.ChangesDataStore):
             ) from None
 
     def filter(self, since: str = "", limit: int = 500):
-        changes = self._collection.find({"timestamp": {"$gte": since}}).limit(limit)
+        changes = self._collection.find({"_id": {"$gte": since}}).limit(limit)
 
         def _clean_result(c):
             _ = c.pop("_id", None)

--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -37,7 +37,7 @@ class Session(interfaces.Session):
 
     @property
     def changes(self):
-        pass
+        return ChangesStore(self._collection)
 
 
 class BaseStore(interfaces.DataStore):
@@ -73,6 +73,30 @@ class BaseStore(interfaces.DataStore):
             raise exceptions.DoesNotExist(
                 "cannot fetch data with id " '"%s": data does not exist' % id
             )
+
+
+class ChangesStore(interfaces.ChangesDataStore):
+    def __init__(self, collection):
+        self._collection = collection
+
+    def add(self, change: dict):
+        change["_id"] = change["timestamp"]
+        try:
+            self._collection.insert_one(change)
+        except pymongo.errors.DuplicateKeyError:
+            raise exceptions.AlreadyExists(
+                "cannot add data with id "
+                '"%s": the id is already in use' % change["_id"]
+            ) from None
+
+    def filter(self, since: str = "", limit: int = 500):
+        changes = self._collection.find({"timestamp": {"$gte": since}}).limit(limit)
+
+        def _clean_result(c):
+            _ = c.pop("_id", None)
+            return c
+
+        return (_clean_result(c) for c in changes)
 
 
 class DocumentStore(BaseStore):

--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -37,7 +37,7 @@ class Session(interfaces.Session):
 
     @property
     def changes(self):
-        return ChangesStore(self._collection)
+        return ChangesStore(self._mongodb_client.collection(colname="changes"))
 
 
 class BaseStore(interfaces.DataStore):

--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -35,6 +35,10 @@ class Session(interfaces.Session):
     def journals(self):
         return JournalStore(self._collection)
 
+    @property
+    def changes(self):
+        pass
+
 
 class BaseStore(interfaces.DataStore):
     def __init__(self, collection):

--- a/documentstore/interfaces.py
+++ b/documentstore/interfaces.py
@@ -76,7 +76,7 @@ class Session(abc.ABC):
             self._observers = {}
             observers = self._observers
 
-        observers.setdefault(event, []).append(callback)
+        observers.setdefault(event, set()).add(callback)
 
     def notify(self, event, data):
         """Notifica a ocorrência de `event`.

--- a/documentstore/interfaces.py
+++ b/documentstore/interfaces.py
@@ -23,6 +23,19 @@ class DataStore(abc.ABC):
         pass
 
 
+class ChangesDataStore(abc.ABC):
+    """Interface manipulação de dados de mudanças.
+    """
+
+    @abc.abstractmethod
+    def add(self, data: dict) -> None:
+        pass
+
+    @abc.abstractmethod
+    def filter(self, since: str = "", limit: int = 500) -> list:
+        pass
+
+
 class Session(abc.ABC):
     """Concentra os pontos de acesso aos repositórios de dados.
 
@@ -45,6 +58,13 @@ class Session(abc.ABC):
     @abc.abstractmethod
     def documents_bundles(self) -> DataStore:
         """Ponto de acesso à instância de ``DataStore``.
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
+    def changes(self) -> ChangesDataStore:
+        """Ponto de acesso à instância de ``ChangesDataStore``.
         """
         pass
 
@@ -71,16 +91,3 @@ class Session(abc.ABC):
                     repr(callback),
                     event,
                 )
-
-
-class ChangesDataStore(abc.ABC):
-    """Interface manipulação de dados de mudanças.
-    """
-
-    @abc.abstractmethod
-    def add(self, data: dict) -> None:
-        pass
-
-    @abc.abstractmethod
-    def filter(self, since: str = "", limit: int = 500) -> list:
-        pass

--- a/documentstore/interfaces.py
+++ b/documentstore/interfaces.py
@@ -26,7 +26,7 @@ class DataStore(abc.ABC):
 class Session(abc.ABC):
     """Concentra os pontos de acesso aos repositórios de dados.
 
-    Classes `Session` implementam o padrão Observable com a finalidade de 
+    Classes `Session` implementam o padrão Observable com a finalidade de
     suportar um sistema de eventos.
     """
 
@@ -71,3 +71,16 @@ class Session(abc.ABC):
                     repr(callback),
                     event,
                 )
+
+
+class ChangesDataStore(abc.ABC):
+    """Interface manipulação de dados de mudanças.
+    """
+
+    @abc.abstractmethod
+    def add(self, data: dict) -> None:
+        pass
+
+    @abc.abstractmethod
+    def filter(self, since: str = "", limit: int = 500) -> list:
+        pass

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -314,12 +314,21 @@ class CreateJournal(CommandHandler):
         return result
 
 
+class FetchChanges(CommandHandler):
+    """Recupera lista de mudanças das entidades.
+
+    :param since: (Opcional) timestamp UTC, inicia a lista de resultados na mudança
+    imediatamente posterior ao timestamp informado.
+    :param limit: (Opcional) Limita o total de resultados obtidos. O valor padrão é 500.
+    """
+
+    def __call__(self, since: str = "", limit: int = 500):
+        session = self.Session()
+        return session.changes.filter(since=since, limit=limit)
+
+
 def log_change(data, session, now=utcnow, entity="", deleted=False):
-    change = {
-        "timestamp": now(),
-        "entity": entity,
-        "id": data["id"]
-    }
+    change = {"timestamp": now(), "entity": entity, "id": data["id"]}
 
     if deleted:
         change["deleted"] = True
@@ -393,4 +402,5 @@ def get_handlers(
             SessionWrapper
         ),
         "create_journal": CreateJournal(SessionWrapper),
+        "fetch_changes": FetchChanges(SessionWrapper),
     }

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from documentstore import interfaces, exceptions, domain
 
 
@@ -94,3 +96,27 @@ def document_registry_data_fixture(prefix=""):
             },
         ],
     }
+
+
+class InMemoryChangesDataStore(interfaces.ChangesDataStore):
+    def __init__(self):
+        self._data_store = OrderedDict()
+
+    def add(self, change: dict):
+
+        if change["timestamp"] in self._data_store:
+            raise exceptions.AlreadyExists()
+        else:
+            self._data_store[change["timestamp"]] = change
+
+    def filter(self, since: str = "", limit: int = 500):
+
+        first = 0
+        for i, change_key in enumerate(self._data_store):
+            if self._data_store[change_key]["timestamp"] < since:
+                continue
+            else:
+                first = i
+                break
+
+        return list(self._data_store.values())[first:limit]

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -8,6 +8,7 @@ class Session(interfaces.Session):
         self._documents = InMemoryDocumentStore()
         self._documents_bundles = InMemoryDocumentsBundleStore()
         self._journals = InMemoryJournalStore()
+        self._changes = InMemoryChangesDataStore()
 
     @property
     def documents(self):
@@ -20,6 +21,10 @@ class Session(interfaces.Session):
     @property
     def journals(self):
         return self._journals
+
+    @property
+    def changes(self):
+        return self._changes
 
 
 class InMemoryDataStore(interfaces.DataStore):

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -180,3 +180,135 @@ class MongoClientStub:
 class SessionTests(SessionTestMixin, unittest.TestCase):
     def Session(self):
         return adapters.Session(MongoClientStub())
+
+
+class ChangesStoreTestMixin:
+    def test_add_returns_none(self):
+        store = self.Store()
+
+        self.assertIsNone(
+            store.add(
+                {
+                    "timestamp": "2018-08-05T23:03:44.971230Z",
+                    "id": "0034-8910-rsp-48-2-0347",
+                    "entity": "document",
+                }
+            )
+        )
+
+    def test_add_requires_timestamp(self):
+        store = self.Store()
+
+        self.assertRaises(
+            KeyError,
+            store.add,
+            {
+                "seq": "2018-08-05T23:03:44.971230Z",
+                "id": "0034-8910-rsp-48-2-0347",
+                "entity": "document",
+            },
+        )
+
+    def test_add_raises_error_when_timestamp_already_exists(self):
+        store = self.Store()
+
+        store.add(
+            {
+                "timestamp": "2018-08-05T23:03:44.971230Z",
+                "id": "0034-8910-rsp-48-2-0347",
+                "entity": "document",
+            }
+        )
+
+        self.assertRaises(
+            exceptions.AlreadyExists,
+            store.add,
+            {
+                "timestamp": "2018-08-05T23:03:44.971230Z",
+                "id": "0034-8910-rsp-48-2-0347",
+                "entity": "document",
+            },
+        )
+
+    def test_filter_returns_empty_list(self):
+        store = self.Store()
+        self.assertEqual(store.filter(), [])
+
+    def test_filter_returns_list(self):
+        store = self.Store()
+
+        changes = [
+            {
+                "timestamp": "2018-08-05T23:03:44.971230Z",
+                "id": "0034-8910-rsp-48-2-0347",
+                "entity": "document",
+            },
+            {
+                "timestamp": "2018-08-05T23:03:47.891432Z",
+                "id": "0034-8910-rsp-48-2-0348",
+                "entity": "document",
+            },
+        ]
+
+        for change in changes:
+            store.add(change)
+
+        self.assertEqual(store.filter(), changes)
+
+    def test_filter_since(self):
+
+        store = self.Store()
+
+        changes = [
+            {
+                "timestamp": "2018-08-05T23:03:44.971230Z",
+                "id": "0034-8910-rsp-48-2-0347",
+                "entity": "document",
+            },
+            {
+                "timestamp": "2018-08-05T23:03:47.891432Z",
+                "id": "0034-8910-rsp-48-2-0348",
+                "entity": "document",
+            },
+            {
+                "timestamp": "2018-08-05T23:06:47.621560Z",
+                "id": "0034-8910-rsp-48-2-0348",
+                "entity": "document",
+            },
+        ]
+
+        for change in changes:
+            store.add(change)
+
+        self.assertEqual(store.filter(since="2018-08-05T23:03:47.891432Z"), changes[1:])
+
+    def test_filter_limit(self):
+
+        store = self.Store()
+
+        changes = [
+            {
+                "timestamp": "2018-08-05T23:03:44.971230Z",
+                "id": "0034-8910-rsp-48-2-0347",
+                "entity": "document",
+            },
+            {
+                "timestamp": "2018-08-05T23:03:47.891432Z",
+                "id": "0034-8910-rsp-48-2-0348",
+                "entity": "document",
+            },
+            {
+                "timestamp": "2018-08-05T23:06:47.621560Z",
+                "id": "0034-8910-rsp-48-2-0348",
+                "entity": "document",
+            },
+        ]
+
+        for change in changes:
+            store.add(change)
+
+        self.assertEqual(store.filter(limit=2), changes[:2])
+
+
+class InMemoryChangesStoreTest(ChangesStoreTestMixin, unittest.TestCase):
+    Store = apptesting.InMemoryChangesDataStore

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -135,7 +135,7 @@ class SessionTestMixin:
         callback.assert_called_once_with("foo", session)
 
     def test_observe_ignores_duplicated_event_callback_pairs(self):
-        """Serão ignorados os registros duplicados de pares evento-callback. 
+        """Serão ignorados os registros duplicados de pares evento-callback.
         """
         callback = Mock()
         session = self.Session()
@@ -206,7 +206,7 @@ class ChangesStoreTestMixin:
             )
         )
 
-    def test_add_requires_timestamp(self):
+    def test_add_raises_error_when_timestamp_key_doesnt_exist(self):
         store = self.Store()
 
         self.assertRaises(
@@ -242,7 +242,7 @@ class ChangesStoreTestMixin:
 
     def test_filter_returns_empty_list(self):
         store = self.Store()
-        self.assertEqual(store.filter(), [])
+        self.assertEqual(list(store.filter()), [])
 
     def test_filter_returns_list(self):
         store = self.Store()
@@ -263,7 +263,7 @@ class ChangesStoreTestMixin:
         for change in changes:
             store.add(change)
 
-        self.assertEqual(store.filter(), changes)
+        self.assertEqual(list(store.filter()), changes)
 
     def test_filter_since(self):
 
@@ -290,7 +290,7 @@ class ChangesStoreTestMixin:
         for change in changes:
             store.add(change)
 
-        self.assertEqual(store.filter(since="2018-08-05T23:03:47.891432Z"), changes[1:])
+        self.assertEqual(list(store.filter(since="2018-08-05T23:03:47.891432Z")), changes[1:])
 
     def test_filter_limit(self):
 
@@ -317,8 +317,13 @@ class ChangesStoreTestMixin:
         for change in changes:
             store.add(change)
 
-        self.assertEqual(store.filter(limit=2), changes[:2])
+        self.assertEqual(list(store.filter(limit=2)), changes[:2])
 
 
 class InMemoryChangesStoreTest(ChangesStoreTestMixin, unittest.TestCase):
     Store = apptesting.InMemoryChangesDataStore
+
+
+class ChangesStoreTest(ChangesStoreTestMixin, unittest.TestCase):
+    def Store(self):
+        return adapters.ChangesStore(apptesting.MongoDBCollectionStub())

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -51,20 +51,19 @@ class CreateDocumentsBundleTest(unittest.TestCase):
         )
 
     def test_command_notify_event(self):
-        mock_callback = mock.Mock()
-        _services, session = make_services(
-            subscribers=[(services.Events.DOCUMENTSBUNDLE_CREATED, mock_callback)]
-        )
-        _services.get("create_documents_bundle")(id="xpto", docs=["/document/1"])
-        mock_callback.assert_called_once_with(
-            {
-                "id": "xpto",
-                "docs": ["/document/1"],
-                "metadata": None,
-                "bundle": mock.ANY,
-            },
-            session,
-        )
+        _services, session = make_services()
+
+        with mock.patch.object(session, "notify") as mock_notify:
+            _services.get("create_documents_bundle")(id="xpto", docs=["/document/1"])
+            mock_notify.assert_called_once_with(
+                services.Events.DOCUMENTSBUNDLE_CREATED,
+                {
+                    "id": "xpto",
+                    "docs": ["/document/1"],
+                    "metadata": None,
+                    "bundle": mock.ANY,
+                },
+            )
 
 
 class FetchDocumentsBundleTest(unittest.TestCase):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -39,6 +39,17 @@ class CreateDocumentsBundleTest(unittest.TestCase):
         self.command(id="xpto")
         self.assertRaises(exceptions.AlreadyExists, self.command, id="xpto")
 
+    def test_command_adds_entry_to_changelog(self):
+        self.assertFalse(
+            ("xpto", "DocumentsBundle")
+            in [(c["id"], c["entity"]) for c in self.services.get("fetch_changes")()]
+        )
+        self.command(id="xpto")
+        self.assertTrue(
+            ("xpto", "DocumentsBundle")
+            in [(c["id"], c["entity"]) for c in self.services.get("fetch_changes")()]
+        )
+
 
 class FetchDocumentsBundleTest(unittest.TestCase):
     def setUp(self):
@@ -176,6 +187,21 @@ class UpdateDocumentsBundleTest(unittest.TestCase):
         )
 
 
+class UpdateDocumentsBundle_NoDatetimeMock_Test(unittest.TestCase):
+    def setUp(self):
+        self.services = make_services()
+        self.command = self.services.get("update_documents_bundle_metadata")
+
+    def test_command_adds_entry_to_changelog(self):
+        self.assertEqual(0, len(self.services.get("fetch_changes")()))
+        self.services["create_documents_bundle"](
+            id="xpto", metadata={"publication_year": "2018", "volume": "2"}
+        )
+        self.assertEqual(1, len(self.services.get("fetch_changes")()))
+        self.command(id="xpto", metadata={"publication_year": "2019"})
+        self.assertEqual(2, len(self.services.get("fetch_changes")()))
+
+
 class AddDocumentToDocumentsBundleTest(unittest.TestCase):
     def setUp(self):
         self.services = make_services()
@@ -204,6 +230,13 @@ class AddDocumentToDocumentsBundleTest(unittest.TestCase):
         self.assertRaises(
             exceptions.AlreadyExists, self.command, id="xpto", doc="/document/1"
         )
+
+    def test_command_adds_entry_to_changelog(self):
+        self.assertEqual(0, len(self.services.get("fetch_changes")()))
+        self.services["create_documents_bundle"](id="xpto")
+        self.assertEqual(1, len(self.services.get("fetch_changes")()))
+        self.command(id="xpto", doc="/document/1")
+        self.assertEqual(2, len(self.services.get("fetch_changes")()))
 
 
 class InsertDocumentToDocumentsBundleTest(unittest.TestCase):
@@ -251,6 +284,13 @@ class InsertDocumentToDocumentsBundleTest(unittest.TestCase):
             doc="/document/1",
         )
 
+    def test_command_adds_entry_to_changelog(self):
+        self.assertEqual(0, len(self.services["fetch_changes"]()))
+        self.services["create_documents_bundle"](id="xpto")
+        self.assertEqual(1, len(self.services["fetch_changes"]()))
+        self.command(id="xpto", index=2, doc="/document/1")
+        self.assertEqual(2, len(self.services["fetch_changes"]()))
+
 
 class CreateJournalTest(unittest.TestCase):
     def setUp(self):
@@ -279,3 +319,7 @@ class CreateJournalTest(unittest.TestCase):
         self.command(id="xpto")
         self.assertRaises(exceptions.AlreadyExists, self.command, id="xpto")
 
+    def test_command_adds_entry_to_changelog(self):
+        self.assertEqual(0, len(self.services["fetch_changes"]()))
+        self.command(id="xpto")
+        self.assertEqual(1, len(self.services["fetch_changes"]()))

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -155,8 +155,8 @@ class UpdateDocumentsBundleTest(unittest.TestCase):
 
     def test_command_remove_metadata(self):
         """
-        Por ora, a maneira de remover um metadado é através da atribuição de uma 
-        string vazia para o mesmo. Note que este procedimento não removerá o metadado 
+        Por ora, a maneira de remover um metadado é através da atribuição de uma
+        string vazia para o mesmo. Note que este procedimento não removerá o metadado
         do manifesto.
         """
         self.services["create_documents_bundle"](
@@ -278,3 +278,4 @@ class CreateJournalTest(unittest.TestCase):
     def test_command_raises_exception_if_already_exists(self):
         self.command(id="xpto")
         self.assertRaises(exceptions.AlreadyExists, self.command, id="xpto")
+


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona a API de mudança utilizando a infraestrutura de eventos.

#### Onde a revisão poderia começar?

Para visualizar as mudanças realizadas é necessário verificar os seguintes modulos: 

adapters.ChangesStore
adapters.Session.changes
interfaces.ChangesDataStore
services.log_change
services.FetchChanges
services.DEFAULT_SUBSCRIBERS


#### Como este poderia ser testado manualmente?

Executando os testes: **python setup.py test** ou executando manualmente os seguintes comandos: 

Utilizando a infraestrutura de teste:
```python
from tests import apptesting
session = apptesting.Session()
from documentstore import services
services = services.get_handlers(lambda: session)
services['register_document']
services['register_document']('S0034-89102014000200347', "https://raw.githubusercontent.com/scieloorg/packtools/master/tests/samples/0034-8910-rsp-48-2-0347.xml")
session.changes.filter()
```
Ou com um mongoDB local(necessário uma instância de mongoDB): 

```python
from documentstore import services
from documentstore.adapters import Session, MongoDB
mongodb = MongoDB("mongodb://localhost:27017/admin")
session = Session(mongodb)
services = services.get_handlers(lambda: session)
services['register_document']
services['register_document']('S0034-89102014000200347', "https://raw.githubusercontent.com/scieloorg/packtools/master/tests/samples/0034-8910-rsp-48-2-0347.xml")
session.changes.filter()
```

Para testar especificamente o ```adapters.ChangesStore.add``` e ```adapters.ChangesStore.filter```

```python
from documentstore.adapters import Session, MongoDB
mongodb = MongoDB("mongodb://localhost:27017/admin")
session = Session(mongodb)
list(session.changes.filter())
session.changes.add({'timestamp': "2018-08-05T23:03:44.971230Z", "id":"xpto", "entity":"document"})
list(session.changes.filter())
```

#### Algum cenário de contexto que queira dar?

Esse código será executado toda vez que os seguintes eventos forem disparados:

```python
Events.DOCUMENT_REGISTERED
Events.DOCUMENT_VERSION_REGISTERED
Events.ASSET_VERSION_REGISTERED
Events.DOCUMENTSBUNDLE_CREATED
Events.DOCUMENTSBUNDLE_METATADA_UPDATED
Events.DOCUMENT_ADDED_TO_DOCUMENTSBUNDLE
Events.DOCUMENT_INSERTED_TO_DOCUMENTSBUNDLE

```

### Screenshots

Testando a API de mudança, com a infraestrutura de testes: 


<img width="1440" alt="screenshot 2019-02-20 10 38 09" src="https://user-images.githubusercontent.com/373745/53095435-a0292f00-34fb-11e9-953b-53179a5e8c57.png">

Testando ```adapters.ChangesStore.add``` e ```adapters.ChangesStore.filter```:

<img width="1369" alt="screenshot 2019-02-20 10 41 49" src="https://user-images.githubusercontent.com/373745/53095645-234a8500-34fc-11e9-84fe-80c84223026d.png">


#### Quais são tickets relevantes?

https://github.com/scieloorg/document-store/issues/50

### Referências

Não há.
