### PR TITLE
 #72 adiciona set e get para o 'provisional'

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -823,3 +823,13 @@ class Journal:
 
     def remove_issue(self, issue: str) -> None:
         self.manifest = BundleManifest.remove_item(self._manifest, issue)
+
+    @property
+    def provisional(self):
+        return BundleManifest.get_component(self.manifest, "provisional")
+
+    @provisional.setter
+    def provisional(self, provisional: str) -> None:
+        self.manifest = BundleManifest.set_component(
+            self._manifest, "provisional", provisional
+        )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1477,3 +1477,13 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             journal.remove_issue,
             "0034-8910-rsp-48-2",
         )
+
+    def test_provisional_is_empty_str(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        self.assertEqual(journal.provisional, "")
+
+    def test_set_provisional(self):
+        journal = domain.Journal(id="0034-8910-rsp-48-2")
+        journal.provisional = "0034-8910-rsp-48-3"
+        self.assertEqual(journal.provisional, "0034-8910-rsp-48-3")
+        self.assertEqual(journal.manifest["provisional"], "0034-8910-rsp-48-3")


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR adiciona o set e o get para gerenciar o bundle `provisional` no `Journal`

#### Onde a revisão poderia começar?
Pelo `documentstore/domain.py` 

#### Como este poderia ser testado manualmente?
pelo comando `python setup.py test`

#### Quais são tickets relevantes?
Fix #72 