### PR TITLE
Torna possível configurar o DSN do MongoDB na app

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ digitais;
 
 ## Implantação local
 
+Configurando a aplicação:
+
+
+diretiva no arquivo .ini | variável de ambiente   | valor padrão
+-------------------------|------------------------|--------------------
+kernel.app.mongodb.dsn   | KERNEL_APP_MONGODB_DSN | mongodb://db:27017
+
+
+
 Executando a aplicação:
 
 ```docker-compose up -d```

--- a/production.ini
+++ b/production.ini
@@ -8,6 +8,8 @@ pyramid.debug_routematch = false
 pyramid.debug_templates = false
 pyramid.default_locale_name = en
 
+;kernel.app.mongodb.dsn =
+
 [server:main]
 use = egg:gunicorn#main
 host = 0.0.0.0


### PR DESCRIPTION
#### O que esse PR faz?

Implementa um mecanismo para tornar possível configurar a aplicação RESTful
por meio de variáveis de ambiente, arquivo de configurações e valor
padrão (seguindo essa ordem de precedência).

#### Onde a revisão poderia começar?

Penso que o ponto chave é a função `restfulapi.parse_settings`.

#### Como este poderia ser testado manualmente?

python setup.py test

#### Algum cenário de contexto que queira dar?

Esta mudança, além de simplesmente permitir a configuração por meio de variáveis de ambiente, define um mecanismo, uma maneira de configurar a aplicação Pyramid (interface RESTful).

### Screenshots

#### Quais são tickets relevantes?

### Referências

#81 

