### PR TITLE
[Domain][Journal] Incluir campo para representar o "Bundle" de aop

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -831,5 +831,13 @@ class Journal:
     @provisional.setter
     def provisional(self, provisional: str) -> None:
         self.manifest = BundleManifest.set_component(
-            self._manifest, "provisional", provisional
+            self._manifest, "provisional", str(provisional)
         )
+
+    @property
+    def ahead_of_print_bundle(self) -> str:
+        return BundleManifest.get_component(self.manifest, "aop", "")
+
+    @ahead_of_print_bundle.setter
+    def ahead_of_print_bundle(self, value: str) -> None:
+        self.manifest = BundleManifest.set_component(self._manifest, "aop", str(value))

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1487,3 +1487,12 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         journal.provisional = "0034-8910-rsp-48-3"
         self.assertEqual(journal.provisional, "0034-8910-rsp-48-3")
         self.assertEqual(journal.manifest["provisional"], "0034-8910-rsp-48-3")
+
+    def test_set_ahead_of_print_bundle(self):
+        journal = domain.Journal(id="0034-8910-rsp")
+        journal.ahead_of_print_bundle = "0034-8910-rsp-aop"
+        self.assertEqual("0034-8910-rsp-aop", journal.manifest["aop"])
+
+    def test_ahead_of_print_bundle_return_empty_str(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        self.assertEqual(journal.ahead_of_print_bundle, "")


### PR DESCRIPTION

#### O que esse PR faz?
Criar set e get para atributo de bundle de artigos _ahead of print_ em `Journal`.

#### Onde a revisão poderia começar?
documentstore/domain.py

#### Como este poderia ser testado manualmente?
python setup.py test

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#71 
### Referências
N/A