### PR TITLE
Adiciona AddIssueToJournal, InsertIssueToJournal, RemoveIssueFromJournal

### DIFF
--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -24,6 +24,9 @@ class Events(Enum):
     DOCUMENT_ADDED_TO_DOCUMENTSBUNDLE = auto()
     DOCUMENT_INSERTED_TO_DOCUMENTSBUNDLE = auto()
     JOURNAL_CREATED = auto()
+    ISSUE_ADDED_TO_JOURNAL = auto()
+    ISSUE_INSERTED_TO_JOURNAL = auto()
+    ISSUE_REMOVED_FROM_JOURNAL = auto()
 
 
 class CommandHandler:
@@ -314,6 +317,42 @@ class CreateJournal(CommandHandler):
         return result
 
 
+class AddIssueToJournal(CommandHandler):
+    def __call__(self, id: str, issue: str) -> None:
+        session = self.Session()
+        _journal = session.journals.fetch(id)
+        _journal.add_issue(issue)
+        session.journals.update(_journal)
+        session.notify(
+            Events.ISSUE_ADDED_TO_JOURNAL,
+            {"journal": _journal, "id": id, "issue": issue},
+        )
+
+
+class InsertIssueToJournal(CommandHandler):
+    def __call__(self, id: str, index: int, issue: str) -> None:
+        session = self.Session()
+        _journal = session.journals.fetch(id)
+        _journal.insert_issue(index, issue)
+        session.journals.update(_journal)
+        session.notify(
+            Events.ISSUE_INSERTED_TO_JOURNAL,
+            {"journal": _journal, "id": id, "index": index, "issue": issue},
+        )
+
+
+class RemoveIssueFromJournal(CommandHandler):
+    def __call__(self, id: str, issue: str) -> None:
+        session = self.Session()
+        _journal = session.journals.fetch(id)
+        _journal.remove_issue(issue)
+        session.journals.update(_journal)
+        session.notify(
+            Events.ISSUE_REMOVED_FROM_JOURNAL,
+            {"journal": _journal, "id": id, "issue": issue},
+        )
+
+
 class FetchChanges(CommandHandler):
     """Recupera lista de mudanças das entidades.
 
@@ -402,5 +441,8 @@ def get_handlers(
             SessionWrapper
         ),
         "create_journal": CreateJournal(SessionWrapper),
+        "add_issue_to_journal": AddIssueToJournal(SessionWrapper),
+        "insert_issue_to_journal": InsertIssueToJournal(SessionWrapper),
+        "remove_issue_from_journal": RemoveIssueFromJournal(SessionWrapper),
         "fetch_changes": FetchChanges(SessionWrapper),
     }

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -128,7 +128,6 @@ class InMemoryChangesDataStore(interfaces.ChangesDataStore):
 
 
 class MongoDBCollectionStub:
-
     def __init__(self):
         self._mongo_store = OrderedDict()
 
@@ -155,7 +154,6 @@ class MongoDBCollectionStub:
 
 
 class SliceResultStub:
-
     def __init__(self, data):
         self._data = data
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -290,7 +290,9 @@ class ChangesStoreTestMixin:
         for change in changes:
             store.add(change)
 
-        self.assertEqual(list(store.filter(since="2018-08-05T23:03:47.891432Z")), changes[1:])
+        self.assertEqual(
+            list(store.filter(since="2018-08-05T23:03:47.891432Z")), changes[1:]
+        )
 
     def test_filter_limit(self):
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona os CommandHandles `AddIssueToJournal`, `InsertIssueToJournal` e `RemoveIssueFromJournal` em `services`. Assim, é possível compor os periódicos com fascículos.

#### Onde a revisão poderia começar?
Em `documentstore/services.py`.

#### Como este poderia ser testado manualmente?
Através do `python setup.py test`, rodar os test cases `AddIssueToJournalTest`, `InsertIssueToJournalTest` e `RemoveIssueFromJournalTest`.

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
Related #70 .

### Referências
Nenhuma.
