### PR TITLE
Adiciona a property .issues para o domínio do Journal

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -2,7 +2,7 @@ import itertools
 from copy import deepcopy
 from io import BytesIO
 import re
-from typing import Union, Callable, Any, Tuple
+from typing import Union, Callable, Any, Tuple, List
 from datetime import datetime
 
 import requests
@@ -823,6 +823,10 @@ class Journal:
 
     def remove_issue(self, issue: str) -> None:
         self.manifest = BundleManifest.remove_item(self._manifest, issue)
+
+    @property
+    def issues(self) -> List[str]:
+        return self.manifest["items"]
 
     @property
     def provisional(self):

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1478,6 +1478,26 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "0034-8910-rsp-48-2",
         )
 
+    def test_get_issues(self):
+        journal = domain.Journal(id="0034-8910-rsp")
+        input_issues = [
+            "0034-8910-rsp-48-1",
+            "0034-8910-rsp-48-2",
+            "0034-8910-rsp-48-3",
+        ]
+
+        for issue in input_issues:
+            journal.insert_issue(0, issue)
+
+        self.assertEqual(
+            ["0034-8910-rsp-48-3", "0034-8910-rsp-48-2", "0034-8910-rsp-48-1"],
+            journal.issues,
+        )
+
+    def test_get_issues_should_be_empty(self):
+        journal = domain.Journal(id="0034-8910-rsp")
+        self.assertEqual([], journal.issues)
+
     def test_provisional_is_empty_str(self):
         journal = domain.Journal(id="0034-8910-rsp-48-2")
         self.assertEqual(journal.provisional, "")


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona a propriedade `.issues` ao domínio do Journal.

#### Onde a revisão poderia começar?
Nos arquivos:
- `documentstore/domain.py`
- `tests/test_domain.py`

#### Como este poderia ser testado manualmente?
Da seguinte maneira:
- Instanciando um objeto do tipo Journal
- Adicionando issues ao objeto
- acessando a propriedade `.issues` e conferindo o resultado

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
close #86 

### Referências
N/A
