### PR TITLE
Altera DocumentsBundle.documents p/ utilizar a property manifest

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -512,7 +512,7 @@ class DocumentsBundle:
 
     @property
     def documents(self):
-        return self._manifest["items"]
+        return self.manifest["items"]
 
 
 class Journal:

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -128,7 +128,6 @@ class InMemoryChangesDataStore(interfaces.ChangesDataStore):
 
 
 class MongoDBCollectionStub:
-
     def __init__(self):
         self._mongo_store = OrderedDict()
 
@@ -155,7 +154,6 @@ class MongoDBCollectionStub:
 
 
 class SliceResultStub:
-
     def __init__(self, data):
         self._data = data
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -290,7 +290,9 @@ class ChangesStoreTestMixin:
         for change in changes:
             store.add(change)
 
-        self.assertEqual(list(store.filter(since="2018-08-05T23:03:47.891432Z")), changes[1:])
+        self.assertEqual(
+            list(store.filter(since="2018-08-05T23:03:47.891432Z")), changes[1:]
+        )
 
     def test_filter_limit(self):
 


### PR DESCRIPTION
#### O que esse PR faz?
Altera a property `DocumentsBundle.documents` para utilizar a property `manifest` ao invés de utilizar o atributo `_manifest`, garantindo a utilização do _copy-on-read_ implementado na property.

#### Onde a revisão poderia começar?
Em `documentstore/domain.py`.

#### Como este poderia ser testado manualmente?
Rodando `python setup.py test`, os testes `DocumentsBundleTest.test_documents_*`.

#### Algum cenário de contexto que queira dar?
Detalhes no ticket #33.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#91, #33

### Referências
Nenhuma.
