### PR TITLE
[Services] Criar comandos para set, get e remove de bundle de aop

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -845,3 +845,6 @@ class Journal:
     @ahead_of_print_bundle.setter
     def ahead_of_print_bundle(self, value: str) -> None:
         self.manifest = BundleManifest.set_component(self._manifest, "aop", str(value))
+
+    def remove_ahead_of_print_bundle(self) -> None:
+        self.manifest = BundleManifest.remove_component(self._manifest, "aop")

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -27,6 +27,8 @@ class Events(Enum):
     ISSUE_ADDED_TO_JOURNAL = auto()
     ISSUE_INSERTED_TO_JOURNAL = auto()
     ISSUE_REMOVED_FROM_JOURNAL = auto()
+    AHEAD_OF_PRINT_BUNDLE_SET_TO_JOURNAL = auto()
+    AHEAD_OF_PRINT_BUNDLE_REMOVED_FROM_JOURNAL = auto()
 
 
 class CommandHandler:
@@ -353,6 +355,30 @@ class RemoveIssueFromJournal(CommandHandler):
         )
 
 
+class SetAheadOfPrintBundleToJournal(CommandHandler):
+    def __call__(self, id: str, aop: str) -> None:
+        session = self.Session()
+        _journal = session.journals.fetch(id)
+        _journal.ahead_of_print_bundle = aop
+        session.journals.update(_journal)
+        session.notify(
+            Events.AHEAD_OF_PRINT_BUNDLE_SET_TO_JOURNAL,
+            {"journal": _journal, "id": id, "aop": aop},
+        )
+
+
+class RemoveAheadOfPrintBundleFromJournal(CommandHandler):
+    def __call__(self, id: str) -> None:
+        session = self.Session()
+        _journal = session.journals.fetch(id)
+        _journal.remove_ahead_of_print_bundle()
+        session.journals.update(_journal)
+        session.notify(
+            Events.AHEAD_OF_PRINT_BUNDLE_REMOVED_FROM_JOURNAL,
+            {"journal": _journal, "id": id},
+        )
+
+
 class FetchChanges(CommandHandler):
     """Recupera lista de mudanças das entidades.
 
@@ -445,4 +471,10 @@ def get_handlers(
         "insert_issue_to_journal": InsertIssueToJournal(SessionWrapper),
         "remove_issue_from_journal": RemoveIssueFromJournal(SessionWrapper),
         "fetch_changes": FetchChanges(SessionWrapper),
+        "set_ahead_of_print_bundle_to_journal": SetAheadOfPrintBundleToJournal(
+            SessionWrapper
+        ),
+        "remove_ahead_of_print_bundle_from_journal": RemoveAheadOfPrintBundleFromJournal(
+            SessionWrapper
+        ),
     }

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1516,3 +1516,18 @@ class JournalTest(UnittestMixin, unittest.TestCase):
     def test_ahead_of_print_bundle_return_empty_str(self):
         journal = domain.Journal(id="0034-8910-MR")
         self.assertEqual(journal.ahead_of_print_bundle, "")
+
+    def test_remove_ahead_of_print_bundle(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        journal.ahead_of_print_bundle = "0034-8910-MR"
+        self.assertIn("aop", journal.manifest.keys())
+        journal.remove_ahead_of_print_bundle()
+        self.assertNotIn("aop", journal.manifest.keys())
+
+    def test_remove_ahead_of_print_bundle_raises_exception_if_it_does_not_exist(self):
+        journal = domain.Journal(id="0034-8910-rsp")
+        self._assert_raises_with_message(
+            exceptions.DoesNotExist,
+            'cannot remove component "aop" from bundle: the component does not exist',
+            journal.remove_ahead_of_print_bundle
+        )


### PR DESCRIPTION
#### O que esse PR faz?
Cria comandos para set, get e remove de bundle de aop

#### Onde a revisão poderia começar?
documentstore/services.py

#### Como este poderia ser testado manualmente?
python setup.py test

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#87 

### Referências
N/A
