### PR TITLE
Refatora método BundleManifest.get_metadata_all

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -365,10 +365,7 @@ class BundleManifest:
 
     @staticmethod
     def get_metadata_all(bundle: dict, name: str) -> Any:
-        try:
-            return bundle["metadata"].get(name, [])
-        except IndexError:
-            return default
+        return bundle["metadata"].get(name, [])
 
     @staticmethod
     def add_item(bundle: dict, item: str, now: Callable[[], str] = utcnow) -> dict:


### PR DESCRIPTION
#### O que esse PR faz?
O método `BundleManifest.get_metadata_all` retornava uma variável inexistente, dessa forma o método foi refatorado para remoção do tratamento de algo que não existe

#### Onde a revisão poderia começar?
No arquivo:
- `documentstore/domain.py` linha `367`

#### Como este poderia ser testado manualmente?
Executando o comando:
- `python setup.py test`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A
