### PR TITLE
Define ordenação na listagem das mudanças

### DIFF
--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -90,13 +90,11 @@ class ChangesStore(interfaces.ChangesDataStore):
             ) from None
 
     def filter(self, since: str = "", limit: int = 500):
-        changes = self._collection.find({"_id": {"$gte": since}}).limit(limit)
-
-        def _clean_result(c):
-            _ = c.pop("_id", None)
-            return c
-
-        return (_clean_result(c) for c in changes)
+        return self._collection.find(
+            {"_id": {"$gte": since}},
+            sort=[("_id", pymongo.ASCENDING)],
+            projection={"_id": False},
+        ).limit(limit)
 
 
 class DocumentStore(BaseStore):

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -139,7 +139,7 @@ class MongoDBCollectionStub:
         else:
             self._mongo_store[data["_id"]] = data
 
-    def find(self, query):
+    def find(self, query, sort=None, projection=None):
         since = query["_id"]["$gte"]
 
         first = 0


### PR DESCRIPTION
#### O que esse PR faz?

Caso não seja definida, a ordenação dos resultados retornados pelo
MongoDB segue o que ele chama de *natural order*, que não
necessariamente obedece a ordem de inclusão. Esta modificação define a ordenação dos resultados.

#### Onde a revisão poderia começar?

`documentstore.adapters.ChangesStore.filters`

#### Como este poderia ser testado manualmente?

#### Algum cenário de contexto que queira dar?

O design da API de mudanças espera que a listagem das mudanças esteja sempre ordenada pela ordem de acontecimento dos eventos. 

### Screenshots

#### Quais são tickets relevantes?

### Referências

- https://docs.mongodb.com/manual/reference/glossary/#term-natural-order