### PR TITLE
Isola MongoDB e comenta o módulo documentstore.adapters

### DIFF
--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -1,3 +1,13 @@
+"""Este módulo deve conter classes concretas que implementam as interfaces
+definidas no módulo `interfaces`, ou seja, adaptadores.
+
+Até o momento atual, há apenas implementações que visam o uso do MongoDB como
+banco de dados e não há qualquer perspectiva para que sejam suportados
+outros bancos de dados. Essa falta de perspectiva se reflete nos identificadores
+das classes `Session`, `BaseStore`, `DocumentStore`, `DocumentsBundleStore` e 
+`JournalStore` que carecem de um componente no nome que os diferencie de outras
+implementações.
+"""
 import pymongo
 
 from . import interfaces
@@ -6,6 +16,12 @@ from . import domain
 
 
 class MongoDB:
+    """Abstrai a configuração do MongoDB de maneira que nenhum outro objeto do 
+    código necessita conhecer detalhes de conexão, nome do banco de dados ou
+    das coleções que armazenam cada tipo de entidade. Caso seja necessário criar
+    índices, aqui é o lugar.
+    """
+
     def __init__(self, uri, dbname="document-store"):
         self._client = pymongo.MongoClient(uri)
         self._dbname = dbname
@@ -18,6 +34,10 @@ class MongoDB:
 
 
 class Session(interfaces.Session):
+    """Implementação de `interfaces.Session` para armazenamento em MongoDB.
+    Trata-se de uma classe concreta e não deve ser generalizada.
+    """
+
     def __init__(self, mongodb_client):
         self._mongodb_client = mongodb_client
 
@@ -41,6 +61,11 @@ class Session(interfaces.Session):
 
 
 class BaseStore(interfaces.DataStore):
+    """Implementação de `interfaces.DataStore` para armazenamento em MongoDB.
+    Trata-se de uma classe abstrata que deve ser estendida por outras que
+    implementam/definem o atributo `DomainClass`.
+    """
+
     def __init__(self, collection):
         self._collection = collection
 
@@ -76,6 +101,10 @@ class BaseStore(interfaces.DataStore):
 
 
 class ChangesStore(interfaces.ChangesDataStore):
+    """Implementação de `interfaces.ChangesDataStore` para armazenamento em 
+    MongoDB.
+    """
+
     def __init__(self, collection):
         self._collection = collection
 

--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -26,11 +26,27 @@ class MongoDB:
         self._client = pymongo.MongoClient(uri)
         self._dbname = dbname
 
-    def db(self):
+    def _db(self):
         return self._client[self._dbname]
 
-    def collection(self, colname):
+    def _collection(self, colname):
         return self.db()[colname]
+
+    @property
+    def documents(self):
+        return self._collection("documents")
+
+    @property
+    def documents_bundles(self):
+        return self._collection("documents_bundles")
+
+    @property
+    def journals(self):
+        return self._collection("journals")
+
+    @property
+    def changes(self):
+        return self._collection("changes")
 
 
 class Session(interfaces.Session):
@@ -43,21 +59,19 @@ class Session(interfaces.Session):
 
     @property
     def documents(self):
-        return DocumentStore(self._mongodb_client.collection(colname="documents"))
+        return DocumentStore(self._mongodb_client.documents)
 
     @property
     def documents_bundles(self):
-        return DocumentsBundleStore(
-            self._mongodb_client.collection(colname="documents_bundles")
-        )
+        return DocumentsBundleStore(self._mongodb_client.documents_bundles)
 
     @property
     def journals(self):
-        return JournalStore(self._mongodb_client.collection(colname="journals"))
+        return JournalStore(self._mongodb_client.journals)
 
     @property
     def changes(self):
-        return ChangesStore(self._mongodb_client.collection(colname="changes"))
+        return ChangesStore(self._mongodb_client.changes)
 
 
 class BaseStore(interfaces.DataStore):

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -183,8 +183,7 @@ class AppTestingSessionTests(SessionTestMixin, unittest.TestCase):
 
 
 class MongoClientStub:
-    def collection(self, colname):
-        return None
+    documents = documents_bundles = journals = changes = None
 
 
 class SessionTests(SessionTestMixin, unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?

Este PR contém 2 commits. O primeiro adiciona docstrings no módulo `documentstore.adapters` para melhor comunicar a intenção e responsabilidades das classes, e o segundo isola detalhes como o nome das coleções do MongoDB da classe `Session`.

#### Onde a revisão poderia começar?

Sugiro começar pela leitura das docstrings.

#### Como este poderia ser testado manualmente?

#### Algum cenário de contexto que queira dar?

### Screenshots

#### Quais são tickets relevantes?

### Referências

