### PR TITLE
Salva Document no MongoDB como campo JSON dentro de documento

### DIFF
--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -103,6 +103,56 @@ def document_registry_data_fixture(prefix=""):
     }
 
 
+def manifest_data_fixture():
+    return {
+        "id": "0034-8910-rsp-48-2",
+        "versions": [
+            {
+              "assets": {
+                "0034-8910-rsp-48-2-0347-gf01.jpg": [
+                  [
+                    "2018-08-05T23:03:44.971230Z",
+                    "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01.jpg"
+                  ]
+                ],
+                "0034-8910-rsp-48-2-0347-gf01-en.jpg": [
+                  [
+                    "2018-08-05T23:08:41.590174Z",
+                    "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01-en.jpg"
+                  ]
+                ],
+              },
+              "data": "https://ssm.scielo.br/tests/samples/0034-8910-rsp-48-2-0347.xml",
+              "timestamp": "2018-08-05T23:02:29.392990Z"
+            },
+            {
+              "assets": {
+                "0034-8910-rsp-48-2-0347-gf02.tiff": [
+                  [
+                    "2018-08-05T23:04:43.323527Z",
+                    "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02.tiff"
+                  ]
+                ],
+                "0034-8910-rsp-48-2-0347-gf02-en.tiff": [
+                  [
+                    "2018-08-05T23:08:50.331687Z",
+                    "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02-en.tiff"
+                  ]
+                ],
+              },
+              "data": "https://ssm.scielo.br/tests/samples/0034-8910-rsp-48-2-0347.xml",
+              "timestamp": "2018-11-16T23:02:29.392990Z"
+            },
+        ],
+        "author": {
+            "last.name": "Smith",
+            "first.name": "Joshua",
+        },
+        "logo.gif": "logo.gif",
+        "namespace$": ["a", "b", "$"],
+    }
+
+
 class InMemoryChangesDataStore(interfaces.ChangesDataStore):
     def __init__(self):
         self._data_store = OrderedDict()


### PR DESCRIPTION
#### O que esse PR faz?
Salva `Document` no MongoDB como campo JSON dentro de outro documento, pois alguns campos de `Document` violam restrição para os nomes de campos. O resultado de consulta de `Document` retorna o conteúdo JSON dentro do documento. Assim, para quem utiliza o adaptador de MongoDB, fica transparente o tratamento.

#### Onde a revisão poderia começar?
Em `documentstore/adapters.py`, na classe `BaseStore`.

#### Como este poderia ser testado manualmente?
Rodando os testes com `python setup.py test`, especificamente os test cases `DocumentsStoreTest`, `DocumentsBundleStoreTest` e `JournalStoreTest` em `test_adapters.py`

#### Algum cenário de contexto que queira dar?
Há uma restrição nos nomes dos campos, que não podem conter pontos ('.') ou cifrões ('$').
Os detalhes estão na issue #67 e na documentação do MongoDB: https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names.

### Screenshots
N/A

#### Quais são tickets relevantes?
Fix #67

### Referências
https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
https://jira.mongodb.org/browse/SERVER-30575
