### PR TITLE
Adiciona endpoint RESTful para registro de periódicos

### DIFF
--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -155,3 +155,31 @@ class SliceResultStub:
 
     def limit(self, val):
         return self._data[:val]
+
+
+def journal_registry_fixture(sufix="", subject_areas=["AGRICULTURAL SCIENCES"]):
+    return {
+            "title": f"Ciência Rural-{sufix}",
+            "mission": {
+                "pt": "Publicar artigos científicos, revisões bibliográficas e notas referentes à área de Ciências Agrárias.",
+                "en": "To publish original articles (full papers), short notes and reviews prepared by national and international experts which contribute to the scientific area of Agronomy, Animal Science, Veterinary Medicine and Forestry Science."
+            },
+            "title_iso": f"Ciênc. rural-{sufix}",
+            "short_title": f"Cienc. Rural-{sufix}",
+            "title_slug": f"ciencia-rural-{sufix}",
+            "acronym": "cr",
+            "scielo_issn": "0103-8478",
+            "print_issn": "0103-8478",
+            "electronic_issn": "1678-4596",
+            "status": {"status": "current"},
+            "subject_areas": subject_areas,
+            "sponsors": [{"name": "FAPERGS"}],
+            "metrics": {"total_h5_index" : 17},
+            "subject_categories": ["AGRONOMY"],
+            "institution_responsible_for": ["Universidade Federal de Santa Maria"],
+            "online_submission_url": "http://mc04.manuscriptcentral.com/cr-scielo",
+            "next_journal": {},
+            "logo_url": "https://homolog.scielo.org/media/assets/cr/glogo.gif",
+            "previous_journal": {"title": "Revista do Centro de Ciências Rurais"},
+            "contact": {"email": "cienciarural@mail.ufsm.br"},
+        }


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona o serviço, rota e testes relacionados ao registro de periódicos a partir de uma interface RESTful.

#### Onde a revisão poderia começar?
A revisão pode ser iniciada pelo arquivo `documentstore/restfulapi.py`

#### Como este poderia ser testado manualmente?

Este pull request pode ser testados pelas alternativas:

- Adição de um periódico
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/1678-4596-cr-49-02 -d  '{"title": "Ciência Rural-1", "mission": {"pt": "Publicar artigos científicos, revisões bibliográficas e notas referentes à área de Ciências Agrárias.", "en": "To publish original articles (full papers), short notes and reviews prepared by national and international experts which contribute to the scientific area of Agronomy, Animal Science, Veterinary Medicine and Forestry Science."}, "title_iso": "Ciênc. rural-1", "short_title": "Cienc. Rural-1", "title_slug": "ciencia-rural-1", "acronym": "cr", "scielo_issn": "0103-8478", "print_issn": "0103-8478", "electronic_issn": "1678-4596", "status": {"status": "current"}, "subject_areas": ["AGRICULTURAL SCIENCES"], "sponsors": [{"name": "FAPERGS"}], "metrics": {"total_h5_index": 17}, "subject_categories": ["AGRONOMY"], "institution_responsible_for": ["Universidade Federal de Santa Maria"], "online_submission_url": "http://mc04.manuscriptcentral.com/cr-scielo", "next_journal": {}, "logo_url": "https://homolog.scielo.org/media/assets/cr/glogo.gif", "previous_journal": {"title": "Revista do Centro de Ciências Rurais"}, "contact": {"email": "cienciarural@mail.ufsm.br"}}'
```
- Execução de testes automatizados `python setup.py test` 
#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#98 

### Referências
N/A
