### PR TITLE
Implementação inicial com cornice_swagger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ certifi==2018.8.24
 chardet==3.0.4
 colander==1.4
 cornice==3.4.0
+cornice-swagger==0.7.0
 hupper==1.3
 idna==2.7
 iso8601==0.1.12

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         "pymongo",
         "pyramid",
         "cornice",
+        "cornice_swagger",
         "colander",
         "python-slugify",
         "scielo-clea",

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1529,7 +1529,7 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         self._assert_raises_with_message(
             exceptions.DoesNotExist,
             'cannot remove component "aop" from bundle: the component does not exist',
-            journal.remove_ahead_of_print_bundle
+            journal.remove_ahead_of_print_bundle,
         )
 
     def test_should_have_a_data_method(self):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -573,8 +573,7 @@ class SetAheadOfPrintBundleToJournalTest(unittest.TestCase):
             JournalStub.ahead_of_print_bundle = mock.Mock()
             mock_fetch.return_value = JournalStub
             self.command(id="0034-8910-rsp", aop="0034-8910-rsp-aop")
-            self.assertEqual(
-                JournalStub.ahead_of_print_bundle, "0034-8910-rsp-aop")
+            self.assertEqual(JournalStub.ahead_of_print_bundle, "0034-8910-rsp-aop")
 
     def test_command_update_journals(self):
         with mock.patch.object(self.session.journals, "fetch") as mock_fetch:
@@ -586,9 +585,7 @@ class SetAheadOfPrintBundleToJournalTest(unittest.TestCase):
                 mock_update.assert_called_once_with(JournalStub)
 
     def test_command_success(self):
-        self.assertIsNone(
-            self.command(id="0034-8910-rsp", aop="0034-8910-rsp-aop")
-        )
+        self.assertIsNone(self.command(id="0034-8910-rsp", aop="0034-8910-rsp-aop"))
 
     def test_command_notify_event(self):
         with mock.patch.object(self.session.journals, "fetch") as mock_fetch:
@@ -619,11 +616,7 @@ class RemoveAheadOfPrintBundleFromJournalTest(unittest.TestCase):
         self.assertTrue(callable(self.command))
 
     def test_command_raises_exception_if_journal_does_not_exist(self):
-        self.assertRaises(
-            exceptions.DoesNotExist,
-            self.command,
-            id="0101-8910-csp",
-        )
+        self.assertRaises(exceptions.DoesNotExist, self.command, id="0101-8910-csp")
 
     def test_command_calls_remove_ahead_of_print(self):
         with mock.patch.object(self.session.journals, "fetch") as mock_fetch:
@@ -643,11 +636,7 @@ class RemoveAheadOfPrintBundleFromJournalTest(unittest.TestCase):
                 mock_update.assert_called_once_with(JournalStub)
 
     def test_command_raises_exception_if_ahead_of_print_does_not_exist(self):
-        self.assertRaises(
-            exceptions.DoesNotExist,
-            self.command,
-            id="0034-8910-rsp"
-        )
+        self.assertRaises(exceptions.DoesNotExist, self.command, id="0034-8910-rsp")
 
     def test_command_notify_event(self):
         with mock.patch.object(self.session.journals, "fetch") as mock_fetch:
@@ -658,10 +647,7 @@ class RemoveAheadOfPrintBundleFromJournalTest(unittest.TestCase):
                 self.command(id="0034-8910-rsp")
                 mock_notify.assert_called_once_with(
                     services.Events.AHEAD_OF_PRINT_BUNDLE_REMOVED_FROM_JOURNAL,
-                    {
-                        "journal": JournalStub,
-                        "id": "0034-8910-rsp",
-                    },
+                    {"journal": JournalStub, "id": "0034-8910-rsp"},
                 )
 
 


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona o **cornice swagger** para a documentação dos endpoints da API RestFul.

#### Onde a revisão poderia começar?

No módulo: **documentstore/restfulapi.py**

#### Como este poderia ser testado manualmente?

Rodando o  teste: **python setup.py test** (somente para garantir que os testes estão funcionando)

E manualmente verificar a API  que documenta os endpoints: http://localhost:6543/__api__ (ver imagens na seção de Screenshots) 

#### Algum cenário de contexto que queira dar?

Não há. 

### Screenshots

<img width="1438" alt="screenshot 2019-03-01 11 34 15" src="https://user-images.githubusercontent.com/373745/53644702-f42bc600-3c15-11e9-8fe7-4125700d5074.png">

<img width="1371" alt="screenshot 2019-03-01 11 35 17" src="https://user-images.githubusercontent.com/373745/53644758-19203900-3c16-11e9-99f1-ef29d95259c5.png">


#### Quais são tickets relevantes?

https://github.com/scieloorg/document-store/issues/4

### Referências

https://github.com/Cornices/cornice.ext.swagger
https://pythonhosted.org/cornice-swagger/tutorial.html
