### PR TITLE
Adiciona serviço para recuperar um periódico

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -539,6 +539,17 @@ class Journal:
     def manifest(self, value: dict):
         self._manifest = value
 
+
+    def data(self):
+        """Retorna o manifesto completo de um Journal com os
+        metadados em sua última versão"""
+        _manifest = self.manifest
+
+        for key, value in _manifest["metadata"].items():
+            _manifest["metadata"][key] = value[-1][-1]
+
+        return _manifest
+
     @property
     def mission(self):
         return BundleManifest.get_metadata(self.manifest, "mission", {})

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -326,7 +326,7 @@ class FetchJournal(CommandHandler):
 
     def __call__(self, id: str) -> Journal:
         session = self.Session()
-        return session.journals.fetch(id)
+        return session.journals.fetch(id).data()
 
 
 class AddIssueToJournal(CommandHandler):

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -319,6 +319,16 @@ class CreateJournal(CommandHandler):
         return result
 
 
+class FetchJournal(CommandHandler):
+    """Recupera o Journal a partir do seu identificador.
+
+    :param id: Identificador único do documento."""
+
+    def __call__(self, id: str) -> Journal:
+        session = self.Session()
+        return session.journals.fetch(id)
+
+
 class AddIssueToJournal(CommandHandler):
     def __call__(self, id: str, issue: str) -> None:
         session = self.Session()
@@ -467,6 +477,7 @@ def get_handlers(
             SessionWrapper
         ),
         "create_journal": CreateJournal(SessionWrapper),
+        "fetch_journal": FetchJournal(SessionWrapper),
         "add_issue_to_journal": AddIssueToJournal(SessionWrapper),
         "insert_issue_to_journal": InsertIssueToJournal(SessionWrapper),
         "remove_issue_from_journal": RemoveIssueFromJournal(SessionWrapper),

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1531,3 +1531,20 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             'cannot remove component "aop" from bundle: the component does not exist',
             journal.remove_ahead_of_print_bundle
         )
+
+    def test_should_have_a_data_method(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        self.assertIsNotNone(journal.data())
+
+    def test_should_has_an_empty_metadata(self):
+        journal = domain.Journal(id="0034-8910-MR")
+        self.assertEqual(journal.data()["metadata"], {})
+
+    def test_should_return_latest_metadata_version(self):
+        journal = domain.Journal(id="0034-8910-MR")
+
+        journal.title = "Ciência Agrária 1"
+        self.assertEqual(journal.data()["metadata"]["title"], "Ciência Agrária 1")
+
+        journal.title = "Ciência Agrária 2"
+        self.assertEqual(journal.data()["metadata"]["title"], "Ciência Agrária 2")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -663,3 +663,26 @@ class RemoveAheadOfPrintBundleFromJournalTest(unittest.TestCase):
                         "id": "0034-8910-rsp",
                     },
                 )
+
+
+class FetchJournalTest(unittest.TestCase):
+    def setUp(self):
+        self.services, self.session = make_services()
+        self.command = self.services.get("fetch_journal")
+        create_journal_command = self.services.get("create_journal")
+        create_journal_command(id="1678-4596-cr-49-02")
+
+    def test_assert_command_interface_exists(self):
+        self.assertIsNotNone(self.command)
+        self.assertTrue(callable(self.command))
+
+    def test_should_raise_does_not_exists_exception(self):
+        self.assertRaises(
+            exceptions.DoesNotExist, self.command, id="1678-4596-cr-49-03"
+        )
+
+    def test_should_return_a_journal(self):
+        self.assertIsNotNone(self.command(id="1678-4596-cr-49-02"))
+
+    def test_should_require_an_id(self):
+        self.assertRaises(TypeError, self.command)


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona um serviço responsável por recuperar um `Journal`.

#### Onde a revisão poderia começar?
A revisão de código deve ser iniciada a partir de:
- `documentstore/services.py#L:322` 

#### Como este poderia ser testado manualmente?
Este PR pode ser testado manualmente a partir da instanciação de uma `session` com a posterior execução e captura do comando `fetch_journal`.

Automaticamente este PR pode ser testado por `python setup.py test`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
close #110 

### Referências
N/A
