### PR TITLE
Adiciona REST API PUT de Documents Bundle

### DIFF
--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -108,48 +108,69 @@ def manifest_data_fixture():
         "id": "0034-8910-rsp-48-2",
         "versions": [
             {
-              "assets": {
-                "0034-8910-rsp-48-2-0347-gf01.jpg": [
-                  [
-                    "2018-08-05T23:03:44.971230Z",
-                    "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01.jpg"
-                  ]
-                ],
-                "0034-8910-rsp-48-2-0347-gf01-en.jpg": [
-                  [
-                    "2018-08-05T23:08:41.590174Z",
-                    "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01-en.jpg"
-                  ]
-                ],
-              },
-              "data": "https://ssm.scielo.br/tests/samples/0034-8910-rsp-48-2-0347.xml",
-              "timestamp": "2018-08-05T23:02:29.392990Z"
+                "assets": {
+                    "0034-8910-rsp-48-2-0347-gf01.jpg": [
+                        [
+                            "2018-08-05T23:03:44.971230Z",
+                            "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01.jpg",
+                        ]
+                    ],
+                    "0034-8910-rsp-48-2-0347-gf01-en.jpg": [
+                        [
+                            "2018-08-05T23:08:41.590174Z",
+                            "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01-en.jpg",
+                        ]
+                    ],
+                },
+                "data": "https://ssm.scielo.br/tests/samples/0034-8910-rsp-48-2-0347.xml",
+                "timestamp": "2018-08-05T23:02:29.392990Z",
             },
             {
-              "assets": {
-                "0034-8910-rsp-48-2-0347-gf02.tiff": [
-                  [
-                    "2018-08-05T23:04:43.323527Z",
-                    "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02.tiff"
-                  ]
-                ],
-                "0034-8910-rsp-48-2-0347-gf02-en.tiff": [
-                  [
-                    "2018-08-05T23:08:50.331687Z",
-                    "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02-en.tiff"
-                  ]
-                ],
-              },
-              "data": "https://ssm.scielo.br/tests/samples/0034-8910-rsp-48-2-0347.xml",
-              "timestamp": "2018-11-16T23:02:29.392990Z"
+                "assets": {
+                    "0034-8910-rsp-48-2-0347-gf02.tiff": [
+                        [
+                            "2018-08-05T23:04:43.323527Z",
+                            "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02.tiff",
+                        ]
+                    ],
+                    "0034-8910-rsp-48-2-0347-gf02-en.tiff": [
+                        [
+                            "2018-08-05T23:08:50.331687Z",
+                            "http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02-en.tiff",
+                        ]
+                    ],
+                },
+                "data": "https://ssm.scielo.br/tests/samples/0034-8910-rsp-48-2-0347.xml",
+                "timestamp": "2018-11-16T23:02:29.392990Z",
             },
         ],
-        "author": {
-            "last.name": "Smith",
-            "first.name": "Joshua",
-        },
+        "author": {"last.name": "Smith", "first.name": "Joshua"},
         "logo.gif": "logo.gif",
         "namespace$": ["a", "b", "$"],
+    }
+
+
+def documents_bundle_registry_data_fixture():
+    return {
+        "pid": "0034-891020190001",
+        "year": 2019,
+        "label": "v1n1",
+        "volume": "1",
+        "number": "1",
+        "titles": [
+            {
+                "language": "es",
+                "title": "La convergencia cuidado-educación: dobles desafios a la práctica de la enfermería y salud",
+            },
+            {
+                "language": "pt",
+                "title": "A convergência cuidado-educação: duplos desafios à prática da enfermagem e saúde",
+            },
+            {
+                "language": "en",
+                "title": "Convergence, educational care: double challenges for the practice of nursing and health care",
+            },
+        ],
     }
 
 
@@ -209,27 +230,27 @@ class SliceResultStub:
 
 def journal_registry_fixture(sufix="", subject_areas=["AGRICULTURAL SCIENCES"]):
     return {
-            "title": f"Ciência Rural-{sufix}",
-            "mission": {
-                "pt": "Publicar artigos científicos, revisões bibliográficas e notas referentes à área de Ciências Agrárias.",
-                "en": "To publish original articles (full papers), short notes and reviews prepared by national and international experts which contribute to the scientific area of Agronomy, Animal Science, Veterinary Medicine and Forestry Science."
-            },
-            "title_iso": f"Ciênc. rural-{sufix}",
-            "short_title": f"Cienc. Rural-{sufix}",
-            "title_slug": f"ciencia-rural-{sufix}",
-            "acronym": "cr",
-            "scielo_issn": "0103-8478",
-            "print_issn": "0103-8478",
-            "electronic_issn": "1678-4596",
-            "status": {"status": "current"},
-            "subject_areas": subject_areas,
-            "sponsors": [{"name": "FAPERGS"}],
-            "metrics": {"total_h5_index" : 17},
-            "subject_categories": ["AGRONOMY"],
-            "institution_responsible_for": ["Universidade Federal de Santa Maria"],
-            "online_submission_url": "http://mc04.manuscriptcentral.com/cr-scielo",
-            "next_journal": {},
-            "logo_url": "https://homolog.scielo.org/media/assets/cr/glogo.gif",
-            "previous_journal": {"title": "Revista do Centro de Ciências Rurais"},
-            "contact": {"email": "cienciarural@mail.ufsm.br"},
-        }
+        "title": f"Ciência Rural-{sufix}",
+        "mission": {
+            "pt": "Publicar artigos científicos, revisões bibliográficas e notas referentes à área de Ciências Agrárias.",
+            "en": "To publish original articles (full papers), short notes and reviews prepared by national and international experts which contribute to the scientific area of Agronomy, Animal Science, Veterinary Medicine and Forestry Science.",
+        },
+        "title_iso": f"Ciênc. rural-{sufix}",
+        "short_title": f"Cienc. Rural-{sufix}",
+        "title_slug": f"ciencia-rural-{sufix}",
+        "acronym": "cr",
+        "scielo_issn": "0103-8478",
+        "print_issn": "0103-8478",
+        "electronic_issn": "1678-4596",
+        "status": {"status": "current"},
+        "subject_areas": subject_areas,
+        "sponsors": [{"name": "FAPERGS"}],
+        "metrics": {"total_h5_index": 17},
+        "subject_categories": ["AGRONOMY"],
+        "institution_responsible_for": ["Universidade Federal de Santa Maria"],
+        "online_submission_url": "http://mc04.manuscriptcentral.com/cr-scielo",
+        "next_journal": {},
+        "logo_url": "https://homolog.scielo.org/media/assets/cr/glogo.gif",
+        "previous_journal": {"title": "Revista do Centro de Ciências Rurais"},
+        "contact": {"email": "cienciarural@mail.ufsm.br"},
+    }


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona put_documents_bundle, REST API PUT de Documents Bundle, e schema.

#### Onde a revisão poderia começar?
Em `documentstore/restfulapi.py`

#### Como este poderia ser testado manualmente?
Rodando `python setup.py test`, especificamente os test cases `DocumentsBundleSchemaTest` e `PutDocumentsBundleTest`.

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#100 

### Referências
Nenhuma.