### PR TITLE
Adiciona REST API PATCH para atualizar Documents Bundle

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -3,6 +3,7 @@ import os
 
 from pyramid.config import Configurator
 from pyramid.httpexceptions import (
+    HTTPOk,
     HTTPNotFound,
     HTTPNoContent,
     HTTPCreated,
@@ -127,9 +128,8 @@ class RegisterJournalSchema(colander.MappingSchema):
 class DocumentsBundleSchema(colander.MappingSchema):
     """Representa o schema de dados para registro de Documents Bundle."""
 
-    pid = colander.SchemaNode(colander.String(), missing=colander.drop)
-    year = colander.SchemaNode(colander.Int(), missing=colander.drop)
-    label = colander.SchemaNode(colander.String(), missing=colander.drop)
+    publication_year = colander.SchemaNode(colander.Int(), missing=colander.drop)
+    supplement = colander.SchemaNode(colander.String(), missing=colander.drop)
     volume = colander.SchemaNode(colander.String(), missing=colander.drop)
     number = colander.SchemaNode(colander.String(), missing=colander.drop)
 
@@ -305,6 +305,23 @@ def put_documents_bundle(request):
         return HTTPNoContent("bundle updated successfully")
     else:
         return HTTPCreated("bundle created successfully")
+
+
+@bundles.patch(
+    schema=DocumentsBundleSchema(),
+    validators=(colander_body_validator,),
+    accept="application/json",
+    renderer="json",
+)
+def patch_documents_bundle(request):
+    try:
+        request.services["update_documents_bundle_metadata"](
+            request.matchdict["bundle_id"], metadata=request.validated
+        )
+    except exceptions.DoesNotExist as exc:
+        return HTTPNotFound(str(exc))
+    else:
+        return HTTPOk("bundle updated successfully")
 
 
 @changes.get(accept="application/json", renderer="json")

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -152,9 +152,8 @@ def manifest_data_fixture():
 
 def documents_bundle_registry_data_fixture():
     return {
-        "pid": "0034-891020190001",
-        "year": 2019,
-        "label": "v1n1",
+        "publication_year": 2019,
+        "supplement": "1",
         "volume": "1",
         "number": "1",
         "titles": [


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona REST API PATCH com view `patch_documents_bundle` para atualizar os metadados de um Document Bundle existente. Também corrige o schema `DocumentsBundleSchema`

#### Onde a revisão poderia começar?
Em `documentstore/restfulapi.py`, pela view `patch_documents_bundle`.

#### Como este poderia ser testado manualmente?
```
curl -X PATCH \
  http://0.0.0.0:6543/bundles/0034-8910-rsp-48-2 \
  -H 'Content-Type: application/json' \
  -d '{
	"publication_year": 2019,
	"volume": "25",
	"number": "5"
}'
```

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#100 

### Referências
Nenhuma.
