### PR TITLE
Adiciona endpoint para recuperar periódicos

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -531,7 +531,17 @@ def put_journal(request):
         return HTTPCreated("journal created successfully")
 
 
-@journals.get(accept="application/json", renderer="json")
+@journals.get(
+    schema=RegisterJournalSchema(),
+    response_schemas={
+        "200": RegisterJournalSchema(description="Retorna um periódico"),
+        "404": RegisterJournalSchema(
+            description="Periódico não encontrado"
+        ),
+    },
+    accept="application/json",
+    renderer="json",
+)
 def get_journal(request):
     """Recupera um periódico por meio de seu identificador
     """

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -531,6 +531,19 @@ def put_journal(request):
         return HTTPCreated("journal created successfully")
 
 
+@journals.get(accept="application/json", renderer="json")
+def get_journal(request):
+    """Recupera um periódico por meio de seu identificador
+    """
+
+    try:
+        return request.services["fetch_journal"](id=request.matchdict["journal_id"])
+    except exceptions.DoesNotExist:
+        return HTTPNotFound(
+            'cannot fetch journal with id "%s"' % request.matchdict["journal_id"]
+        )
+
+
 @swagger.get()
 def openAPI_spec(request):
     doc = CorniceSwagger(get_services())

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -350,3 +350,27 @@ class CreateJournalUnitTests(unittest.TestCase):
             subject_areas=["invalid-subject-area"]
         )
         self.assertIsInstance(restfulapi.put_journal(self.request), HTTPBadRequest)
+
+
+class FetchJournalUnitTest(unittest.TestCase):
+    def setUp(self):
+        self.request = make_request()
+        self.config = testing.setUp()
+        self.config.add_route("journals", pattern="/journals/{journal_id}")
+
+        # register a journal
+        self.request.matchdict = {"journal_id": "1678-4596-cr-49-02"}
+        self.request.validated = apptesting.journal_registry_fixture()
+        restfulapi.put_journal(self.request)
+
+    def test_should_return_does_not_exists(self):
+        MockFetchJournal = Mock(side_effect=exceptions.DoesNotExist)
+        self.request.services["fetch_journal"] = MockFetchJournal
+        self.request.matchdict = {"journal_id": "some-random-id-001"}
+        self.assertIsInstance(restfulapi.get_journal(self.request), HTTPNotFound)
+
+    def test_should_fetch_journal(self):
+        self.request.services["fetch_journal"](id="1678-4596-cr-49-02")
+        self.request.matchdict = {"journal_id": "1678-4596-cr-49-02"}
+        journal_data = restfulapi.get_journal(self.request)
+        self.assertIsInstance(journal_data, dict)


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona um endpoint para recuperar periódicos.

#### Onde a revisão poderia começar?
No arquivo: `documentstore/restfulapi.py#L:333`

#### Como este poderia ser testado manualmente?
- Para recuperar um periódico é necessário o seu registro em primeiro caso, para tanto execute um cURL:
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/1678-4596-cr-49-02 -d  '{"title": "Ciência Rural-1", "mission": {"pt": "Publicar artigos científicos, revisões bibliográficas e notas referentes à área de Ciências Agrárias.", "en": "To publish original articles (full papers), short notes and reviews prepared by national and international experts which contribute to the scientific area of Agronomy, Animal Science, Veterinary Medicine and Forestry Science."}, "title_iso": "Ciênc. rural-1", "short_title": "Cienc. Rural-1", "title_slug": "ciencia-rural-1", "acronym": "cr", "scielo_issn": "0103-8478", "print_issn": "0103-8478", "electronic_issn": "1678-4596", "status": {"status": "current"}, "subject_areas": ["AGRICULTURAL SCIENCES"], "sponsors": [{"name": "FAPERGS"}], "metrics": {"total_h5_index": 17}, "subject_categories": ["AGRONOMY"], "institution_responsible_for": ["Universidade Federal de Santa Maria"], "online_submission_url": "http://mc04.manuscriptcentral.com/cr-scielo", "next_journal": {}, "logo_url": "https://homolog.scielo.org/media/assets/cr/glogo.gif", "previous_journal": {"title": "Revista do Centro de Ciências Rurais"}, "contact": {"email": "cienciarural@mail.ufsm.br"}}'
```

 - Posteriormente pode-se acessar a URL `http://0.0.0.0:6543/journals/1678-4596-cr-49-02`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![Screen Shot 2019-03-08 at 5 08 53 PM](https://user-images.githubusercontent.com/4604104/54152127-41304900-441b-11e9-86d5-fda47591ae3a.png)


#### Quais são tickets relevantes?
#98

### Referências
N/A
