### PR TITLE
Adiciona campo title no Document Bundle 2

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -498,6 +498,20 @@ class DocumentsBundle:
             self._manifest, "supplement", _value
         )
 
+    @property
+    def titles(self):
+        return BundleManifest.get_metadata(self.manifest, "titles", {})
+
+    @titles.setter
+    def titles(self, value: dict):
+        try:
+            _value = dict(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                "cannot set titles with value " '"%s": value must be dict' % value
+            ) from None
+        self.manifest = BundleManifest.set_metadata(self._manifest, "titles", _value)
+
     def add_document(self, document: str):
         self.manifest = BundleManifest.add_item(self._manifest, document)
 
@@ -538,7 +552,6 @@ class Journal:
     @manifest.setter
     def manifest(self, value: dict):
         self._manifest = value
-
 
     def data(self):
         """Retorna o manifesto completo de um Journal com os

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -644,6 +644,31 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
         documents_bundle.supplement = 3
         self.assertEqual(documents_bundle.supplement, "3")
 
+    def test_set_titles(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        documents_bundle.titles = {"pt": "Título", "es": "Título", "en": "Title"}
+        self.assertEqual(
+            documents_bundle.titles, {"pt": "Título", "es": "Título", "en": "Title"}
+        )
+        self.assertEqual(
+            documents_bundle.manifest["metadata"]["titles"][-1],
+            (
+                "2018-08-05T22:33:49.795151Z",
+                {"pt": "Título", "es": "Título", "en": "Title"},
+            ),
+        )
+
+    def test_set_titles_content_is_not_validated(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            TypeError,
+            "cannot set titles with value " '"invalid-titles": value must be dict',
+            setattr,
+            documents_bundle,
+            "titles",
+            "invalid-titles",
+        )
+
     def test_add_document(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
         documents_bundle.add_document("/documents/0034-8910-rsp-48-2-0275")

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -176,18 +176,22 @@ class FetchDocumentsBundleTest(unittest.TestCase):
 
     def test_fetch_documents_bundle_calls_fetch_documents_bundle_service(self):
         self.request.matchdict["bundle_id"] = "0034-8910-rsp-48-2"
-        MockFetchDocumentsBundle = Mock()
+        MockFetchDocumentsBundle = Mock(return_value={"id": "0034-8910-rsp-48-2"})
         self.request.services["fetch_documents_bundle"] = MockFetchDocumentsBundle
         restfulapi.fetch_documents_bundle(self.request)
         MockFetchDocumentsBundle.assert_called_once_with("0034-8910-rsp-48-2")
 
     def test_fetch_documents_bundle_returns_fetch_documents_bundle_service_return(self):
         self.request.matchdict["bundle_id"] = "0034-8910-rsp-48-2"
-        MockFetchDocumentsBundle = Mock(return_value={id: "0034-8910-rsp-48-2"})
+        expected = apptesting.documents_bundle_registry_data_fixture()
+        data = deepcopy(expected)
+        # Titles no domínio é um dict "language: title"
+        data["titles"] = {
+            title["language"]: title["title"] for title in expected["titles"]
+        }
+        MockFetchDocumentsBundle = Mock(return_value=data)
         self.request.services["fetch_documents_bundle"] = MockFetchDocumentsBundle
-        self.assertEqual(
-            restfulapi.fetch_documents_bundle(self.request), {id: "0034-8910-rsp-48-2"}
-        )
+        self.assertEqual(restfulapi.fetch_documents_bundle(self.request), expected)
 
 
 class DocumentsBundleSchemaTest(unittest.TestCase):
@@ -231,11 +235,16 @@ class PutDocumentsBundleTest(unittest.TestCase):
     def test_put_documents_bundle_calls_create_documents_bundle(self):
         self.request.matchdict["bundle_id"] = "0034-8910-rsp-48-2"
         self.request.validated = apptesting.documents_bundle_registry_data_fixture()
+        expected = deepcopy(self.request.validated)
+        expected["titles"] = {
+            title["language"]: title["title"]
+            for title in self.request.validated["titles"]
+        }
         MockCreateDocumentsBundle = Mock()
         self.request.services["create_documents_bundle"] = MockCreateDocumentsBundle
         restfulapi.put_documents_bundle(self.request)
         MockCreateDocumentsBundle.assert_called_once_with(
-            "0034-8910-rsp-48-2", metadata=self.request.validated
+            "0034-8910-rsp-48-2", metadata=expected
         )
 
     def test_put_documents_bundle_returns_204_if_already_exists(self):
@@ -277,13 +286,18 @@ class PatchDocumentsBundleTest(unittest.TestCase):
     def test_patch_documents_bundle_calls_update_documents_bundle(self):
         self.request.matchdict["bundle_id"] = "0034-8910-rsp-48-2"
         self.request.validated = apptesting.documents_bundle_registry_data_fixture()
+        expected = deepcopy(self.request.validated)
+        expected["titles"] = {
+            title["language"]: title["title"]
+            for title in self.request.validated["titles"]
+        }
         MockUpdateDocumentsBundle = Mock()
         self.request.services[
             "update_documents_bundle_metadata"
         ] = MockUpdateDocumentsBundle
         restfulapi.patch_documents_bundle(self.request)
         MockUpdateDocumentsBundle.assert_called_once_with(
-            "0034-8910-rsp-48-2", metadata=self.request.validated
+            "0034-8910-rsp-48-2", metadata=expected
         )
 
     def test_put_documents_bundle_returns_200_if_updated(self):


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona propriedade `titles` no Document Bundle. Com isso:
-  Foi adicionada a propriedade `titles` em `DocumentsBundle`
- Alteradas as views `fetch_documents_bundle`, `put_documents_bundle` e `patch_documents_bundle` para tratar `titles`

Também foi ajustada a documentação Swagger.

#### Onde a revisão poderia começar?
Em `documentstore/domain.py`, `DocumentsBundle`

#### Como este poderia ser testado manualmente?
```
curl -X PUT \
  http://0.0.0.0:6543/bundles/0034-8910-rsp-48-4 \
  -H 'Content-Type: application/json' \
  -d '{
	"titles": [
		{
			"language": "en",
			"title": "Title"
		},
		{
			"language": "pt",
			"title": "Título"
		}
	]
}'
```

```
curl -X GET \
  http://0.0.0.0:6543/bundles/0034-8910-rsp-48-4 \
  -H 'Content-Type: application/json'
```

```
curl -X PATCH \
  http://0.0.0.0:6543/bundles/0034-8910-rsp-48-4 \
  -H 'Content-Type: application/json' \
  -d '{
	"titles": [
		{
			"language": "en",
			"title": "Title"
		},
		{
			"language": "pt",
			"title": "Título"
		},
		{
			"language": "es",
			"title": "Título"
		}
	]
}'
```

#### Algum cenário de contexto que queira dar?
O título é um dado opcional de fascículos e, por isso, deve ser previsto em `DocumentsBundle`.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#100.

### Referências
http://www.scielo.br/scielo.php?script=sci_issuetoc&pid=0004-273019990004&lng=en&nrm=iso
