### PR TITLE
Remove decoradores duplicados

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -165,7 +165,6 @@ class DocumentsBundleSchema(colander.MappingSchema):
             title = colander.SchemaNode(colander.String(), validator=colander.Length(1))
 
 
-@documents.get(accept="text/xml", renderer="xml")
 class QueryChangeSchema(colander.MappingSchema):
     """Representa os parâmetros de querystring do schema change.
     """
@@ -478,7 +477,6 @@ def patch_documents_bundle(request):
         return HTTPOk("bundle updated successfully")
 
 
-@changes.get(accept="application/json", renderer="json")
 @changes.get(
     schema=ChangeSchema(),
     response_schemas={


### PR DESCRIPTION
#### O que esse PR faz?

Remove decoradores duplicados

#### Onde a revisão poderia começar?

No módulo **documentstore/restfulapi.py**

#### Como este poderia ser testado manualmente?

Manualmente rodando **docker-compose up -d**

#### Algum cenário de contexto que queira dar?

A documentação do cornice swagger estava com erro de duplicidade de decoradores.

### Screenshots

Não há.

#### Quais são tickets relevantes?

Não há.

### Referências

Não há.
