### PR TITLE
Altera JournalSchema para seguir a padronagem do Cornice Swagger

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -119,7 +119,7 @@ class AssetSchema(colander.MappingSchema):
     asset_url = colander.SchemaNode(colander.String(), validator=colander.url)
 
 
-class RegisterJournalSchema(colander.MappingSchema):
+class JournalSchema(colander.MappingSchema):
     """Representa o schema de dados para registro de periódicos.
     """
 
@@ -527,14 +527,14 @@ def fetch_changes(request):
 
 
 @journals.put(
-    schema=RegisterJournalSchema(),
+    schema=JournalSchema(),
     validators=(colander_body_validator,),
     accept="application/json",
     renderer="json",
 )
 def put_journal(request):
     """Registra um periódico a partir de dados submetidos e
-    validados por meio do RegisterJournalSchema."""
+    validados por meio do JournalSchema."""
 
     try:
         request.services["create_journal"](
@@ -549,10 +549,10 @@ def put_journal(request):
 
 
 @journals.get(
-    schema=RegisterJournalSchema(),
+    schema=JournalSchema(),
     response_schemas={
-        "200": RegisterJournalSchema(description="Retorna um periódico"),
-        "404": RegisterJournalSchema(
+        "200": JournalSchema(description="Retorna um periódico"),
+        "404": JournalSchema(
             description="Periódico não encontrado"
         ),
     },

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -133,11 +133,25 @@ class JournalSchema(colander.MappingSchema):
     print_issn = colander.SchemaNode(colander.String())
     electronic_issn = colander.SchemaNode(colander.String())
     status = colander.SchemaNode(colander.Mapping(unknown="preserve"))
-    subject_areas = colander.SchemaNode(colander.List())
-    sponsors = colander.SchemaNode(colander.List())
+
+    @colander.instantiate()
+    class subject_areas(colander.SequenceSchema):
+        name = colander.SchemaNode(colander.String())
+
+    @colander.instantiate()
+    class sponsors(colander.SequenceSchema):
+        sponsor = colander.SchemaNode(colander.Mapping(unknown="preserve"))
+
     metrics = colander.SchemaNode(colander.Mapping(unknown="preserve"))
-    subject_categories = colander.SchemaNode(colander.List())
-    institution_responsible_for = colander.SchemaNode(colander.List())
+
+    @colander.instantiate()
+    class subject_categories(colander.SequenceSchema):
+        name = colander.SchemaNode(colander.String())
+
+    @colander.instantiate()
+    class institution_responsible_for(colander.SequenceSchema):
+        name = colander.SchemaNode(colander.String())
+
     online_submission_url = colander.SchemaNode(
         colander.String(), validator=colander.url
     )


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request ataca duas frentes:
- Renomeia a classe `RegisterJournalSchema` para `JournalSchema` fazendo-a ter um nome mais consistente;
- Altera os tipos `colander.List()` para `colander.Sequence` para que o Cornice Swagger possa renderizar os tipos corretos durante a  renderização da  documentação.  

#### Onde a revisão poderia começar?
No arquivo `documentstore/restfulapi.py` linha `122`

#### Como este poderia ser testado manualmente?
- Deve-se fazer o build da aplicação
- Deve-se rodar a aplicação
- Deve-se inserir um novo `Journal`
- Deve-se acessar o endpoint da api `__api__` e verificar a renderização do schema

#### Algum cenário de contexto que queira dar?
Este PR faz-se necessário para solucionar problemas com a consistência de nomes e adequações ao Cornice Swagger, o funcionamento anterior não deve ser alterado.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A
