### PR TITLE
Retorno dos dados mais novos do manifesto em FetchDocumentsBundle

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -445,6 +445,13 @@ class DocumentsBundle:
     def id(self):
         return self.manifest.get("id", "")
 
+    def data(self):
+        _manifest = self.manifest
+        _manifest["metadata"] = {
+            attr: value[-1][-1] for attr, value in _manifest["metadata"].items()
+        }
+        return _manifest
+
     @property
     def manifest(self):
         return deepcopy(self._manifest)

--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -265,7 +265,7 @@ class CreateDocumentsBundle(CommandHandler):
 class FetchDocumentsBundle(CommandHandler):
     def __call__(self, id: str) -> dict:
         session = self.Session()
-        return session.documents_bundles.fetch(id).manifest
+        return session.documents_bundles.fetch(id).data()
 
 
 class UpdateDocumentsBundleMetadata(CommandHandler):

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -751,6 +751,27 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
             "/documents/0034-8910-rsp-48-2-0275",
         )
 
+    def test_data_is_not_none(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertIsNotNone(documents_bundle.data())
+
+    def test_data_metadata_returns_a_dict(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(documents_bundle.data()["metadata"], {})
+
+    def test_data_returns_latest_metadata_version(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        documents_bundle.titles = {"en": "Title", "pt": "Título"}
+        self.assertEqual(
+            documents_bundle.data()["metadata"]["titles"],
+            {"en": "Title", "pt": "Título"},
+        )
+        documents_bundle.titles = {"en": "Title", "pt": "Título", "es": "Título"}
+        self.assertEqual(
+            documents_bundle.data()["metadata"]["titles"],
+            {"en": "Title", "pt": "Título", "es": "Título"},
+        )
+
 
 class JournalTest(UnittestMixin, unittest.TestCase):
     def setUp(self):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -91,11 +91,7 @@ class FetchDocumentsBundleTest(unittest.TestCase):
         )
         result = self.command(id="xpto")
         self.assertEqual(
-            result["metadata"],
-            {
-                "publication_year": [("2018-08-05T22:33:49.795151Z", "2018")],
-                "volume": [("2018-08-05T22:33:49.795151Z", "2")],
-            },
+            result["metadata"], {"publication_year": "2018", "volume": "2"}
         )
 
     def test_command_with_unexpected_metadata(self):
@@ -105,11 +101,7 @@ class FetchDocumentsBundleTest(unittest.TestCase):
         )
         result = self.command(id="xpto")
         self.assertEqual(
-            result["metadata"],
-            {
-                "publication_year": [("2018-08-05T22:33:49.795151Z", "2018")],
-                "volume": [("2018-08-05T22:33:49.795151Z", "2")],
-            },
+            result["metadata"], {"publication_year": "2018", "volume": "2"}
         )
 
 
@@ -141,14 +133,7 @@ class UpdateDocumentsBundleTest(unittest.TestCase):
         self.command(id="xpto", metadata={"publication_year": "2019"})
         result = self.services["fetch_documents_bundle"](id="xpto")
         self.assertEqual(
-            result["metadata"],
-            {
-                "publication_year": [
-                    ("2018-08-05T22:33:49.795151Z", "2018"),
-                    ("2018-08-05T22:33:49.795151Z", "2019"),
-                ],
-                "volume": [("2018-08-05T22:33:49.795151Z", "2")],
-            },
+            result["metadata"], {"publication_year": "2019", "volume": "2"}
         )
 
     def test_command_with_unexpected_metadata(self):
@@ -158,11 +143,7 @@ class UpdateDocumentsBundleTest(unittest.TestCase):
         self.command(id="xpto", metadata={"unknown": "0"})
         result = self.services["fetch_documents_bundle"](id="xpto")
         self.assertEqual(
-            result["metadata"],
-            {
-                "publication_year": [("2018-08-05T22:33:49.795151Z", "2018")],
-                "volume": [("2018-08-05T22:33:49.795151Z", "2")],
-            },
+            result["metadata"], {"publication_year": "2018", "volume": "2"}
         )
 
     def test_command_remove_metadata(self):
@@ -176,16 +157,7 @@ class UpdateDocumentsBundleTest(unittest.TestCase):
         )
         self.command(id="xpto", metadata={"volume": ""})
         result = self.services["fetch_documents_bundle"](id="xpto")
-        self.assertEqual(
-            result["metadata"],
-            {
-                "publication_year": [("2018-08-05T22:33:49.795151Z", "2018")],
-                "volume": [
-                    ("2018-08-05T22:33:49.795151Z", "2"),
-                    ("2018-08-05T22:33:49.795151Z", ""),
-                ],
-            },
-        )
+        self.assertEqual(result["metadata"], {"publication_year": "2018", "volume": ""})
 
     def test_command_notify_event(self):
         self.services["create_documents_bundle"](


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona método `data` em `DocumentsBundle` para retornar somente os dados mais novos de `metadata` e usa-o no serviço `FetchDocumentsBundle`.

#### Onde a revisão poderia começar?
Em `documentstore/domain.py`, `DocumentsBundle`.

#### Como este poderia ser testado manualmente?
Rodando `python setup.py test`, especialmente os test cases `DocumentsBundleTest` e `FetchDocumentsBundleTest`.

#### Algum cenário de contexto que queira dar?
Como os dados de `BundleManifest` são armazenados com timestamp de forma a manter-se um histórico, é necessário recuperar os dados mais atuais.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#100

### Referências
Nenhuma.
