### PR TITLE
Corrige services.DEFAULT_SUBSCRIBERS, adicionando os observers não setados

### DIFF
--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -449,6 +449,21 @@ DEFAULT_SUBSCRIBERS = [
         functools.partial(log_change, entity="DocumentsBundle"),
     ),
     (Events.JOURNAL_CREATED, functools.partial(log_change, entity="Journal")),
+    (Events.JOURNAL_METATADA_UPDATED, functools.partial(log_change, entity="Journal")),
+    (Events.ISSUE_ADDED_TO_JOURNAL, functools.partial(log_change, entity="Journal")),
+    (Events.ISSUE_INSERTED_TO_JOURNAL, functools.partial(log_change, entity="Journal")),
+    (
+        Events.ISSUE_REMOVED_FROM_JOURNAL,
+        functools.partial(log_change, entity="Journal"),
+    ),
+    (
+        Events.AHEAD_OF_PRINT_BUNDLE_SET_TO_JOURNAL,
+        functools.partial(log_change, entity="Journal"),
+    ),
+    (
+        Events.AHEAD_OF_PRINT_BUNDLE_REMOVED_FROM_JOURNAL,
+        functools.partial(log_change, entity="Journal"),
+    ),
 ]
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona os observers que não estava sendo setados em `services.DEFAULT_SUBSCRIBERS`, que fazia com que as notificações de eventos não fossem registrados. Também foram adicionados alguns testes para validar se o evento a ser notificado no comando está presente na lista.

#### Onde a revisão poderia começar?
Em `documentstore/services.py`, `DEFAULT_SUBSCRIBERS`

#### Como este poderia ser testado manualmente?
Executando os test cases de `test_services.py` com `python setup.py test`.

#### Algum cenário de contexto que queira dar?
Não.

### Screenshots
N/A.

#### Quais são tickets relevantes?
N/A.

### Referências
Nenhuma.
