### PR TITLE
Complementa documentação do put_journal para o cornice swagger

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -593,6 +593,15 @@ def fetch_changes(request):
 @journals.put(
     schema=JournalSchema(),
     validators=(colander_body_validator,),
+    response_schemas={
+        "201": JournalSchema(description="Periódico criado com sucesso"),
+        "204": JournalSchema(
+            description="Não foi realizada alteração para o periódico informado"
+        ),
+        "400": JournalSchema(
+            description="Erro ao processar a requisição, por favor verifique os dados informados"
+        ),
+    },
     accept="application/json",
     renderer="json",
 )


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request complementa a documentação de respostas para o `put_journal` facilitando o seu entendimento por meio da API do cornice swagger. 

#### Onde a revisão poderia começar?
No arquivo `documentstore/restfulapi.py` linha `596`.

#### Como este poderia ser testado manualmente?
- Deve-se fazer o build da aplicação
- Deve-se rodar a aplicação
- Deve-se acessar o endpoint `__api__` e visualizar os valores de respostas.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
close #123 

### Referências
N/A
