### PR TITLE
Adiciona configurações para o coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,26 @@
+[run]
+include = documentstore/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report
+


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona configurações para usar o coverage. É necessário que ele seja instalado em seu ambiente python.

#### Onde a revisão poderia começar?
`.coveragerc`

#### Como este poderia ser testado manualmente?
Executando:
```
coverage run setup.py test
coverage report documentstore/*.py
```

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
N/A.

### Referências
https://coverage.readthedocs.io/en/v4.5.x/install.html.
