### PR TITLE
Corrige o retorno do PUT REST API de Documents Bundle

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -537,7 +537,7 @@ def put_documents_bundle(request):
 @bundles.patch(
     schema=DocumentsBundleSchema(),
     response_schemas={
-        "200": DocumentsBundleSchema(
+        "204": DocumentsBundleSchema(
             description="Documents Bundle atualizado com sucesso."
         ),
         "404": DocumentsBundleSchema(description="Documents Bundle não encontrado."),
@@ -558,7 +558,7 @@ def patch_documents_bundle(request):
     except exceptions.DoesNotExist as exc:
         return HTTPNotFound(str(exc))
     else:
-        return HTTPOk("bundle updated successfully")
+        return HTTPNoContent("bundle updated successfully")
 
 
 @changes.get(

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -300,12 +300,12 @@ class PatchDocumentsBundleTest(unittest.TestCase):
             "0034-8910-rsp-48-2", metadata=expected
         )
 
-    def test_put_documents_bundle_returns_200_if_updated(self):
+    def test_put_documents_bundle_returns_204_if_updated(self):
         self.request.matchdict["bundle_id"] = "0034-8910-rsp-48-2"
         self.request.validated = apptesting.documents_bundle_registry_data_fixture()
         self.request.services["update_documents_bundle_metadata"] = Mock()
         response = restfulapi.patch_documents_bundle(self.request)
-        self.assertIsInstance(response, HTTPOk)
+        self.assertIsInstance(response, HTTPNoContent)
 
 
 class FetchChangeUnitTest(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o retorno do PUT REST API de Documents Bundle, que deveria ser 204, conforme conversado do comportamento esperado da interface cliente desta solução.

#### Onde a revisão poderia começar?
Em `documentstore/restfulapi.py`, `patch_documents_bundle`.

#### Como este poderia ser testado manualmente?
Rodar o teste:
`tests.test_restfulapi.PatchDocumentsBundleTest.test_put_documents_bundle_returns_204_if_updated`.

#### Algum cenário de contexto que queira dar?
Não.

### Screenshots
N/A.

#### Quais são tickets relevantes?
N/A.

### Referências
https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Methods/PATCH.
