### PR TITLE
Altera o domínio do journal e adequa API para o novo formato

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -572,15 +572,16 @@ class Journal:
 
     @property
     def mission(self):
-        return BundleManifest.get_metadata(self.manifest, "mission", {})
+        return BundleManifest.get_metadata(self.manifest, "mission", [])
 
     @mission.setter
-    def mission(self, value: dict):
+    def mission(self, value: List[dict]):
         try:
-            value = dict(value)
+            value = list([dict(mission) for mission in value])
         except (TypeError, ValueError):
             raise TypeError(
-                "cannot set mission with value " '"%s": value must be dict' % value
+                "cannot set mission with value "
+                '"%s": value must be list of dict' % value
             ) from None
         self.manifest = BundleManifest.set_metadata(self._manifest, "mission", value)
 

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -140,9 +140,14 @@ class JournalSchema(colander.MappingSchema):
     """
 
     title = colander.SchemaNode(colander.String(), missing=colander.drop)
-    mission = colander.SchemaNode(
-        colander.Mapping(unknown="preserve"), missing=colander.drop
-    )
+
+    @colander.instantiate(missing=colander.drop)
+    class mission(colander.SequenceSchema):
+        @colander.instantiate()
+        class mission(colander.MappingSchema):
+            language = colander.SchemaNode(colander.String())
+            value = colander.SchemaNode(colander.String())
+
     title_iso = colander.SchemaNode(colander.String(), missing=colander.drop)
     short_title = colander.SchemaNode(colander.String(), missing=colander.drop)
     title_slug = colander.SchemaNode(colander.String(), missing=colander.drop)
@@ -646,7 +651,6 @@ def fetch_changes(request):
 def put_journal(request):
     """Registra um periódico a partir de dados submetidos e
     validados por meio do JournalSchema."""
-
     try:
         request.services["create_journal"](
             id=request.matchdict["journal_id"], metadata=request.validated

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -230,10 +230,16 @@ class SliceResultStub:
 def journal_registry_fixture(sufix="", subject_areas=["AGRICULTURAL SCIENCES"]):
     return {
         "title": f"Ciência Rural-{sufix}",
-        "mission": {
-            "pt": "Publicar artigos científicos, revisões bibliográficas e notas referentes à área de Ciências Agrárias.",
-            "en": "To publish original articles (full papers), short notes and reviews prepared by national and international experts which contribute to the scientific area of Agronomy, Animal Science, Veterinary Medicine and Forestry Science.",
-        },
+        "mission": [
+            {
+                "language": "pt",
+                "value": "Publicar artigos científicos, revisões bibliográficas e notas referentes à área de Ciências Agrárias.",
+            },
+            {
+                "language": "en",
+                "value": "To publish original articles (full papers), short notes and reviews prepared by national and international experts which contribute to the scientific area of Agronomy, Animal Science, Veterinary Medicine and Forestry Science.",
+            },
+        ],
         "title_iso": f"Ciênc. rural-{sufix}",
         "short_title": f"Cienc. Rural-{sufix}",
         "title_slug": f"ciencia-rural-{sufix}",

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -804,28 +804,57 @@ class JournalTest(UnittestMixin, unittest.TestCase):
 
     def test_set_mission(self):
         documents_bundle = domain.Journal(id="0034-8910-rsp-48-2")
-        documents_bundle.mission = {
-            "pt": "Publicar trabalhos científicos originais sobre a Amazonia.",
-            "es": "Publicar trabajos científicos originales sobre Amazonia.",
-            "en": "To publish original scientific papers about Amazonia.",
-        }
+
+        documents_bundle.mission = [
+            {
+                "language": "pt",
+                "value": "Publicar trabalhos científicos originais sobre a Amazonia.",
+            },
+            {
+                "language": "es",
+                "value": "Publicar trabajos científicos originales sobre Amazonia.",
+            },
+            {
+                "language": "en",
+                "value": "To publish original scientific papers about Amazonia.",
+            },
+        ]
+
         self.assertEqual(
             documents_bundle.mission,
-            {
-                "pt": "Publicar trabalhos científicos originais sobre a Amazonia.",
-                "es": "Publicar trabajos científicos originales sobre Amazonia.",
-                "en": "To publish original scientific papers about Amazonia.",
-            },
+            [
+                {
+                    "language": "pt",
+                    "value": "Publicar trabalhos científicos originais sobre a Amazonia.",
+                },
+                {
+                    "language": "es",
+                    "value": "Publicar trabajos científicos originales sobre Amazonia.",
+                },
+                {
+                    "language": "en",
+                    "value": "To publish original scientific papers about Amazonia.",
+                },
+            ],
         )
         self.assertEqual(
             documents_bundle.manifest["metadata"]["mission"][-1],
             (
                 "2018-08-05T22:33:49.795151Z",
-                {
-                    "pt": "Publicar trabalhos científicos originais sobre a Amazonia.",
-                    "es": "Publicar trabajos científicos originales sobre Amazonia.",
-                    "en": "To publish original scientific papers about Amazonia.",
-                },
+                [
+                    {
+                        "language": "pt",
+                        "value": "Publicar trabalhos científicos originais sobre a Amazonia.",
+                    },
+                    {
+                        "language": "es",
+                        "value": "Publicar trabajos científicos originales sobre Amazonia.",
+                    },
+                    {
+                        "language": "en",
+                        "value": "To publish original scientific papers about Amazonia.",
+                    },
+                ],
             ),
         )
 
@@ -833,7 +862,8 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         documents_bundle = domain.Journal(id="0034-8910-rsp-48-2")
         self._assert_raises_with_message(
             TypeError,
-            "cannot set mission with value " '"mission-invalid": value must be dict',
+            "cannot set mission with value "
+            '"mission-invalid": value must be list of dict',
             setattr,
             documents_bundle,
             "mission",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -290,7 +290,10 @@ class CreateJournalTest(CommandTestMixin, unittest.TestCase):
                 id="xpto",
                 metadata={
                     "title": "Journal Title",
-                    "mission": {"pt": "Missão do Periódico", "en": "Journal Mission"},
+                    "mission": [
+                        {"language": "pt", "value": "Missão do Periódico"},
+                        {"language": "en", "value": "Journal Mission"},
+                    ],
                 },
             )
         )
@@ -652,7 +655,10 @@ class UpdateJornalMetadataTest(CommandTestMixin, unittest.TestCase):
             id="1678-4596-cr",
             metadata={
                 "title": "Journal Title",
-                "mission": {"pt": "Missão do Periódico", "en": "Journal Mission"},
+                "mission": [
+                    {"language": "pt", "value": "Missão do Periódico"},
+                    {"language": "en", "value": "Journal Mission"},
+                ],
             },
         )
 
@@ -670,11 +676,11 @@ class UpdateJornalMetadataTest(CommandTestMixin, unittest.TestCase):
             id="1678-4596-cr",
             metadata={
                 "title": "Journal New Title",
-                "mission": {
-                    "pt": "Missão do Periódico",
-                    "en": "Journal Mission",
-                    "es": "Misión de la Revista",
-                },
+                "mission": [
+                    {"language": "pt", "value": "Missão do Periódico"},
+                    {"language": "en", "value": "Journal Mission"},
+                    {"language": "es", "value": "Misión de la Revista"},
+                ],
             },
         )
         result = self.services["fetch_journal"](id="1678-4596-cr")
@@ -682,11 +688,11 @@ class UpdateJornalMetadataTest(CommandTestMixin, unittest.TestCase):
             result["metadata"],
             {
                 "title": "Journal New Title",
-                "mission": {
-                    "pt": "Missão do Periódico",
-                    "en": "Journal Mission",
-                    "es": "Misión de la Revista",
-                },
+                "mission": [
+                    {"language": "pt", "value": "Missão do Periódico"},
+                    {"language": "en", "value": "Journal Mission"},
+                    {"language": "es", "value": "Misión de la Revista"},
+                ],
             },
         )
 
@@ -704,7 +710,10 @@ class UpdateJornalMetadataTest(CommandTestMixin, unittest.TestCase):
             result["metadata"],
             {
                 "title": "Journal New Title",
-                "mission": {"pt": "Missão do Periódico", "en": "Journal Mission"},
+                "mission": [
+                    {"language": "pt", "value": "Missão do Periódico"},
+                    {"language": "en", "value": "Journal Mission"},
+                ],
                 "title_iso": "Title ISO",
             },
         )
@@ -721,18 +730,21 @@ class UpdateJornalMetadataTest(CommandTestMixin, unittest.TestCase):
             result["metadata"],
             {
                 "title": "",
-                "mission": {"pt": "Missão do Periódico", "en": "Journal Mission"},
+                "mission": [
+                    {"language": "pt", "value": "Missão do Periódico"},
+                    {"language": "en", "value": "Journal Mission"},
+                ],
             },
         )
 
     def test_command_notify_event(self):
         metadata = {
             "title": "Journal New Title",
-            "mission": {
-                "pt": "Missão do Periódico",
-                "en": "Journal Mission",
-                "es": "Misión de la Revista",
-            },
+            "mission": [
+                {"language": "pt", "value": "Missão do Periódico"},
+                {"language": "en", "value": "Journal Mission"},
+                {"language": "es", "value": "Misión de la Revista"},
+            ],
         }
         with mock.patch.object(self.session, "notify") as mock_notify:
             self.command(id="1678-4596-cr", metadata=metadata)


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request altera o tipo de dado para o campo `mission` no domínio do Kernel. Este PR também adequa o schema de dados validado pelo colander.

#### Onde a revisão poderia começar?
- `documentstore/domain.py` linha `578`
- `documentstore/restfulapi.py` linha `144`

#### Como este poderia ser testado manualmente?
Para testar este PR deve-se:
- Executar a API
- Requisitar um novo registro de journal
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/1678-4596-cr-49-03 -d '{"mission": [{"language": "pt", "value": "exemplo"}]}'
```
- Verificar se o registro foi inserido corretamente
- Requisitar uma atualização do registro
```shell
curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/1678-4596-cr-49-03 -d '{"mission": [{"language": "en", "value": "example"}]}'
```
- Verificar se a atualização ocorreu bem

### Testes automatizados
Através do comando `python setup.py test` 

#### Algum cenário de contexto que queira dar?
Esta alteração se fez necessária porque estávamos utilizando de `dado` para definir uma estrutura a ser disponibilizada pelo cliente. Com a finalidade de facilitar a tradução na entrada e saída de dados, resolvemos alterar diretamente o meio de armazenamento do campo.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A
