### PR TITLE
Altera tipo de dado do bundle e adequa API

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -507,15 +507,16 @@ class DocumentsBundle:
 
     @property
     def titles(self):
-        return BundleManifest.get_metadata(self.manifest, "titles", {})
+        return BundleManifest.get_metadata(self.manifest, "titles", [])
 
     @titles.setter
     def titles(self, value: dict):
         try:
-            _value = dict(value)
+            _value = list([dict(title) for title in value])
         except (TypeError, ValueError):
             raise TypeError(
-                "cannot set titles with value " '"%s": value must be dict' % value
+                "cannot set titles with value "
+                '"%s": value must be list of dict' % value
             ) from None
         self.manifest = BundleManifest.set_metadata(self._manifest, "titles", _value)
 

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -159,15 +159,15 @@ def documents_bundle_registry_data_fixture():
         "titles": [
             {
                 "language": "es",
-                "title": "La convergencia cuidado-educación: dobles desafios a la práctica de la enfermería y salud",
+                "value": "La convergencia cuidado-educación: dobles desafios a la práctica de la enfermería y salud",
             },
             {
                 "language": "pt",
-                "title": "A convergência cuidado-educação: duplos desafios à prática da enfermagem e saúde",
+                "value": "A convergência cuidado-educação: duplos desafios à prática da enfermagem e saúde",
             },
             {
                 "language": "en",
-                "title": "Convergence, educational care: double challenges for the practice of nursing and health care",
+                "value": "Convergence, educational care: double challenges for the practice of nursing and health care",
             },
         ],
     }

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -646,15 +646,25 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
 
     def test_set_titles(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.titles = {"pt": "Título", "es": "Título", "en": "Title"}
+        documents_bundle.titles = [
+            {"language": "en", "value": "Title"},
+            {"language": "pt", "value": "Título"},
+        ]
         self.assertEqual(
-            documents_bundle.titles, {"pt": "Título", "es": "Título", "en": "Title"}
+            documents_bundle.titles,
+            [
+                {"language": "en", "value": "Title"},
+                {"language": "pt", "value": "Título"},
+            ],
         )
         self.assertEqual(
             documents_bundle.manifest["metadata"]["titles"][-1],
             (
                 "2018-08-05T22:33:49.795151Z",
-                {"pt": "Título", "es": "Título", "en": "Title"},
+                [
+                    {"language": "en", "value": "Title"},
+                    {"language": "pt", "value": "Título"},
+                ],
             ),
         )
 
@@ -662,7 +672,8 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
         self._assert_raises_with_message(
             TypeError,
-            "cannot set titles with value " '"invalid-titles": value must be dict',
+            "cannot set titles with value "
+            '"invalid-titles": value must be list of dict',
             setattr,
             documents_bundle,
             "titles",
@@ -761,15 +772,29 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
 
     def test_data_returns_latest_metadata_version(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.titles = {"en": "Title", "pt": "Título"}
+        documents_bundle.titles = [
+            {"language": "en", "value": "Title"},
+            {"language": "pt", "value": "Título"},
+        ]
         self.assertEqual(
             documents_bundle.data()["metadata"]["titles"],
-            {"en": "Title", "pt": "Título"},
+            [
+                {"language": "en", "value": "Title"},
+                {"language": "pt", "value": "Título"},
+            ],
         )
-        documents_bundle.titles = {"en": "Title", "pt": "Título", "es": "Título"}
+        documents_bundle.titles = [
+            {"language": "en", "value": "Title"},
+            {"language": "pt", "value": "Título"},
+            {"language": "es", "value": "Título"},
+        ]
         self.assertEqual(
             documents_bundle.data()["metadata"]["titles"],
-            {"en": "Title", "pt": "Título", "es": "Título"},
+            [
+                {"language": "en", "value": "Title"},
+                {"language": "pt", "value": "Título"},
+                {"language": "es", "value": "Título"},
+            ],
         )
 
 

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -185,10 +185,6 @@ class FetchDocumentsBundleTest(unittest.TestCase):
         self.request.matchdict["bundle_id"] = "0034-8910-rsp-48-2"
         expected = apptesting.documents_bundle_registry_data_fixture()
         data = deepcopy(expected)
-        # Titles no domínio é um dict "language: title"
-        data["titles"] = {
-            title["language"]: title["title"] for title in expected["titles"]
-        }
         MockFetchDocumentsBundle = Mock(return_value=data)
         self.request.services["fetch_documents_bundle"] = MockFetchDocumentsBundle
         self.assertEqual(restfulapi.fetch_documents_bundle(self.request), expected)
@@ -236,10 +232,6 @@ class PutDocumentsBundleTest(unittest.TestCase):
         self.request.matchdict["bundle_id"] = "0034-8910-rsp-48-2"
         self.request.validated = apptesting.documents_bundle_registry_data_fixture()
         expected = deepcopy(self.request.validated)
-        expected["titles"] = {
-            title["language"]: title["title"]
-            for title in self.request.validated["titles"]
-        }
         MockCreateDocumentsBundle = Mock()
         self.request.services["create_documents_bundle"] = MockCreateDocumentsBundle
         restfulapi.put_documents_bundle(self.request)
@@ -287,10 +279,6 @@ class PatchDocumentsBundleTest(unittest.TestCase):
         self.request.matchdict["bundle_id"] = "0034-8910-rsp-48-2"
         self.request.validated = apptesting.documents_bundle_registry_data_fixture()
         expected = deepcopy(self.request.validated)
-        expected["titles"] = {
-            title["language"]: title["title"]
-            for title in self.request.validated["titles"]
-        }
         MockUpdateDocumentsBundle = Mock()
         self.request.services[
             "update_documents_bundle_metadata"


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request altera o tipo de dado para o campo `titles` no domínio `DocumentsBundle` do Kernel. Este PR também adequa o schema de dados validado pelo colander.

#### Onde a revisão poderia começar?
- `documentstore/domain.py` linha `515`
- `documentstore/restfulapi.py` linha `216`
- `documentstore/restfulapi.py` linha `509`

#### Como este poderia ser testado manualmente?
Para testar este PR deve-se:
- Executar a API
- Requisitar um novo registro de bundle

```shell
curl -X PUT "http://0.0.0.0:6543/bundles/0034-8910-rsp-48-2" \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json' \
  -d '{
        "publication_year": 2019,
        "volume": "25",
        "titles": [{"language": "pt", "value": "Título do bundle"}]
}'
```
- Verificar se o registro foi inserido corretamente

### Testes automatizados
Através do comando `python setup.py test` 

#### Algum cenário de contexto que queira dar?
Esta alteração se fez necessária porque estávamos utilizando de `dado` para definir uma estrutura a ser disponibilizada pelo cliente. Com a finalidade de facilitar a tradução na entrada e saída de dados, resolvemos alterar diretamente o meio de armazenamento do campo.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A
