### PR TITLE
Atualiza o clea e garante o retorno de todos os itens possíveis no endpoint front

### DIFF
--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -218,33 +218,10 @@ class SanitizeDocumentFront(CommandHandler):
 
     def __call__(self, xml_data: bytes) -> dict:
         clea_article = clea_core.Article(BytesIO(xml_data))
-        front_data = {
-            tag_name: [branch.data for branch in clea_article.get(tag_name)]
-            for tag_name in ["journal-meta", "article-meta"]
+        return {
+            **clea_article.data_full,
+            "aff_contrib_full": clea_join.aff_contrib_full(clea_article),
         }
-        front_data["contrib"] = clea_join.aff_contrib_inner_join(clea_article)
-        return self._rearrange(front_data)
-
-    def _rearrange(self, data):
-        def _first(iterable, default=""):
-            try:
-                return next(iter(iterable))
-            except StopIteration:
-                return default
-
-        _data = {
-            "journal-meta": _first(data["journal-meta"], {}),
-            "article-meta": _first(data["article-meta"], {}),
-        }
-        _data["contrib"] = [
-            {
-                k: v
-                for k, v in contrib.items()
-                if k not in _data["journal-meta"] and k not in _data["article-meta"]
-            }
-            for contrib in data["contrib"]
-        ]
-        return _data
 
 
 class CreateDocumentsBundle(CommandHandler):

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pytz==2018.6
 regex==2018.8.29
 repoze.lru==0.7
 requests==2.20.0
-scielo-clea==0.1.1
+scielo-clea==0.2.0
 simplejson==3.16.0
 six==1.11.0
 translationstring==1.3

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "cornice_swagger",
         "colander",
         "python-slugify",
-        "scielo-clea",
+        "scielo-clea>=0.2.0",
     ],
     test_suite="tests",
     classifiers=(


### PR DESCRIPTION
#### O que esse PR faz?

Atualiza o **clea** para a última versão e ajusta o endpoint **/front** do documents para retornar quase todos os elementos do **XML**.

#### Onde a revisão poderia começar?

documentstore/services.py:SanitizeDocumentFront

#### Como este poderia ser testado manualmente?

Acessando o endpoint: http://0.0.0.0:6543/documents/{ID}/front

#### Algum cenário de contexto que queira dar?

Não

### Screenshots

![Screenshot 2019-04-10 14 01 56](https://user-images.githubusercontent.com/373745/55898553-38a56c80-5b99-11e9-91db-301b2fdc34ac.png)

#### Quais são tickets relevantes?

Necessidade motivada pelo ticket: https://github.com/scieloorg/opac-airflow/issues/7

### Referências

Não há.

