### PR TITLE
Adiciona decorator *retry_gracefully*

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ diretiva no arquivo .ini | variável de ambiente   | valor padrão
 kernel.app.mongodb.dsn   | KERNEL_APP_MONGODB_DSN | mongodb://db:27017
 
 
+Configurações avançadas:
+
+
+variável de ambiente      | valor padrão
+--------------------------|-------------
+KERNEL_LIB_MAX_RETRIES    | 4
+KERNEL_LIB_BACKOFF_FACTOR | 1.2
+
 
 Executando a aplicação:
 


### PR DESCRIPTION
#### O que esse PR faz?
Acrescenta um *decorator factory* capaz de tentar novamente quando uma exceção recuperável for
lançada, contribuindo para a resiliência da aplicação na sua integração com o object-store.

Foram acrescentadas 2 variáveis de ambiente que configuram o intervalo e
quantidade máxima de tentativas. Penso que tratam-se de parâmetros
internos do Kernel enquanto lib, portanto são carregados diretamente no
módulo e não por meio do arquivo de configuração da app pyramid (.ini).


#### Onde a revisão poderia começar?

Acredito que o módulo de testes seja um bom ponto de partida: `tests.test_domain.RetryGracefullyDecoratorTests`.

#### Como este poderia ser testado manualmente?

Duas maneiras: 
1. Executando a suíte de testes automatizados;
2. Executando uma instância local e provocando instabilidade na conexão de rede durante operações que envolvem a obtenção do XML a partir do object-store (recuperação de um XML por exemplo)

#### Algum cenário de contexto que queira dar?

Decidi implementar esta funcionalidade enquanto realizava testes no Kernel onde estavam sendo carregados centenas de documentos em poucos segundos. Os documentos apontavam para o arquivo XML hospedado no GitHub e em alguns momentos ocorriam timeouts.

### Screenshots

#### Quais são tickets relevantes?

### Referências
