### PR TITLE
Adiciona suporte ao registro dos PDFs dos documentos

### DIFF
--- a/documentstore/services.py
+++ b/documentstore/services.py
@@ -153,7 +153,7 @@ class FetchAssetsList(CommandHandler):
         return document.version(index=version_index)
 
 
-class RegisterAssetVersion(BaseRegisterDocument):
+class RegisterAssetVersion(CommandHandler):
     """Registra uma nova versão do ativo digital de documento já registrado.
 
     :param id: Identificador alfanumérico para o documento.

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -124,6 +124,7 @@ def manifest_data_fixture():
                 },
                 "data": "https://ssm.scielo.br/tests/samples/0034-8910-rsp-48-2-0347.xml",
                 "timestamp": "2018-08-05T23:02:29.392990Z",
+                "renditions": [],
             },
             {
                 "assets": {
@@ -142,6 +143,7 @@ def manifest_data_fixture():
                 },
                 "data": "https://ssm.scielo.br/tests/samples/0034-8910-rsp-48-2-0347.xml",
                 "timestamp": "2018-11-16T23:02:29.392990Z",
+                "renditions": [],
             },
         ],
         "author": {"last.name": "Smith", "first.name": "Joshua"},

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -373,4 +373,3 @@ class MongoDBTests(unittest.TestCase):
             "mongodb://test_db:27017", dbname="store", mongoclient=mock_mongoclient
         )
         mock_mongoclient.assert_not_called()
-

--- a/tests/test_documentmanifest.py
+++ b/tests/test_documentmanifest.py
@@ -13,6 +13,9 @@ add_version = functools.partial(DocumentManifest.add_version, now=fake_utcnow)
 add_asset_version = functools.partial(
     DocumentManifest.add_asset_version, now=fake_utcnow
 )
+add_rendition_version = functools.partial(
+    DocumentManifest.add_rendition_version, now=fake_utcnow
+)
 
 
 class TestNewManifest(unittest.TestCase):
@@ -35,6 +38,7 @@ class TestAddVersion(unittest.TestCase):
                     "data": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.xml",
                     "assets": {"0034-8910-rsp-48-2-0275-gf01.gif": []},
                     "timestamp": fake_utcnow(),
+                    "renditions": [],
                 }
             ],
         }
@@ -68,6 +72,7 @@ class TestAddVersion(unittest.TestCase):
                     "data": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.xml",
                     "assets": {"0034-8910-rsp-48-2-0275-gf01.gif": []},
                     "timestamp": fake_utcnow(),
+                    "renditions": [],
                 }
             ],
         }
@@ -229,3 +234,238 @@ class TestAddVersion(unittest.TestCase):
         )
 
         self.assertEqual(new_version["_revision"], "a1eda318424")
+
+
+class AddRenditionVersionTests(unittest.TestCase):
+    def test_first_version(self):
+        doc = {"id": "0034-8910-rsp-48-2-0275", "versions": [{"renditions": []}]}
+        expected = {
+            "id": "0034-8910-rsp-48-2-0275",
+            "versions": [
+                {
+                    "renditions": [
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.pdf",
+                                    "size_bytes": 243000,
+                                }
+                            ],
+                            "mimetype": "application/pdf",
+                            "lang": "pt-br",
+                        }
+                    ]
+                }
+            ],
+        }
+
+        self.assertEqual(
+            add_rendition_version(
+                doc,
+                "0034-8910-rsp-48-2-0275.pdf",
+                "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.pdf",
+                "application/pdf",
+                "pt-br",
+                243000,
+            ),
+            expected,
+        )
+
+    def test_second_version(self):
+        doc = {
+            "id": "0034-8910-rsp-48-2-0275",
+            "versions": [
+                {
+                    "renditions": [
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.pdf",
+                                    "size_bytes": 243000,
+                                }
+                            ],
+                            "mimetype": "application/pdf",
+                            "lang": "pt-br",
+                        }
+                    ]
+                }
+            ],
+        }
+        expected = {
+            "id": "0034-8910-rsp-48-2-0275",
+            "versions": [
+                {
+                    "renditions": [
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.pdf",
+                                    "size_bytes": 243000,
+                                },
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",  # vai repetir nos testes
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-v2.pdf",
+                                    "size_bytes": 223461,
+                                },
+                            ],
+                            "mimetype": "application/pdf",
+                            "lang": "pt-br",
+                        }
+                    ]
+                }
+            ],
+        }
+
+        self.assertEqual(
+            add_rendition_version(
+                doc,
+                "0034-8910-rsp-48-2-0275.pdf",
+                "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-v2.pdf",
+                "application/pdf",
+                "pt-br",
+                223461,
+            ),
+            expected,
+        )
+
+    def test_filename_and_lang_must_match(self):
+        doc = {
+            "id": "0034-8910-rsp-48-2-0275",
+            "versions": [
+                {
+                    "renditions": [
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.pdf",
+                                    "size_bytes": 243000,
+                                }
+                            ],
+                            "mimetype": "application/pdf",
+                            "lang": "pt-br",
+                        }
+                    ]
+                }
+            ],
+        }
+        expected = {
+            "id": "0034-8910-rsp-48-2-0275",
+            "versions": [
+                {
+                    "renditions": [
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.pdf",
+                                    "size_bytes": 243000,
+                                }
+                            ],
+                            "mimetype": "application/pdf",
+                            "lang": "pt-br",
+                        },
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",  # vai repetir nos testes
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-v2.pdf",
+                                    "size_bytes": 223461,
+                                }
+                            ],
+                            "mimetype": "application/pdf",
+                            "lang": "pt",
+                        },
+                    ]
+                }
+            ],
+        }
+
+        self.assertEqual(
+            add_rendition_version(
+                doc,
+                "0034-8910-rsp-48-2-0275.pdf",
+                "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-v2.pdf",
+                "application/pdf",
+                "pt",
+                223461,
+            ),
+            expected,
+        )
+
+    def test_filename_and_mimetype_must_match(self):
+        doc = {
+            "id": "0034-8910-rsp-48-2-0275",
+            "versions": [
+                {
+                    "renditions": [
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.pdf",
+                                    "size_bytes": 243000,
+                                }
+                            ],
+                            "mimetype": "application/pdf",
+                            "lang": "pt-br",
+                        }
+                    ]
+                }
+            ],
+        }
+        expected = {
+            "id": "0034-8910-rsp-48-2-0275",
+            "versions": [
+                {
+                    "renditions": [
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.pdf",
+                                    "size_bytes": 243000,
+                                }
+                            ],
+                            "mimetype": "application/pdf",
+                            "lang": "pt-br",
+                        },
+                        {
+                            "filename": "0034-8910-rsp-48-2-0275.pdf",
+                            "data": [
+                                {
+                                    "timestamp": "2018-08-05T22:33:49.795151Z",  # vai repetir nos testes
+                                    "url": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-v2.pdf",
+                                    "size_bytes": 223461,
+                                }
+                            ],
+                            "mimetype": "application/octet-stream",
+                            "lang": "pt-br",
+                        },
+                    ]
+                }
+            ],
+        }
+
+        self.assertEqual(
+            add_rendition_version(
+                doc,
+                "0034-8910-rsp-48-2-0275.pdf",
+                "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-v2.pdf",
+                "application/octet-stream",
+                "pt-br",
+                223461,
+            ),
+            expected,
+        )

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -24,6 +24,7 @@ SAMPLE_MANIFEST = {
                 ]
             },
             "timestamp": "2018-08-05T23:02:29.392990Z",
+            "renditions": [],
         },
         {
             "data": "/rawfiles/2d3ad9c6bc656/0034-8910-rsp-48-2-0275.xml",
@@ -36,6 +37,84 @@ SAMPLE_MANIFEST = {
                 ]
             },
             "timestamp": "2018-08-05T23:30:29.392990Z",
+            "renditions": [],
+        },
+    ],
+}
+SAMPLE_MANIFEST_WITH_RENDITIONS = {
+    "id": "0034-8910-rsp-48-2-0275",
+    "versions": [
+        {
+            "data": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.xml",
+            "assets": {
+                "0034-8910-rsp-48-2-0275-gf01.gif": [
+                    (
+                        "2018-08-05T23:03:44.971230Z",
+                        "/rawfiles/8e644999a8fa4/0034-8910-rsp-48-2-0275-gf01.gif",
+                    ),
+                    (
+                        "2018-08-05T23:08:41.590174Z",
+                        "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-gf01.gif",
+                    ),
+                ]
+            },
+            "timestamp": "2018-08-05T23:02:29.392990Z",
+            "renditions": [
+                {
+                    "filename": "0034-8910-rsp-48-2-0275-pt.pdf",
+                    "mimetype": "application/pdf",
+                    "lang": "pt",
+                    "data": [
+                        {
+                            "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-pt.pdf",
+                            "size_bytes": 123456,
+                        }
+                    ],
+                }
+            ],
+        },
+        {
+            "data": "/rawfiles/2d3ad9c6bc656/0034-8910-rsp-48-2-0275.xml",
+            "assets": {
+                "0034-8910-rsp-48-2-0275-gf01.gif": [
+                    (
+                        "2018-08-05T23:30:29.392995Z",
+                        "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-gf01.gif",
+                    )
+                ]
+            },
+            "timestamp": "2018-08-05T23:30:29.392990Z",
+            "renditions": [
+                {
+                    "filename": "0034-8910-rsp-48-2-0275-v2-pt.pdf",
+                    "mimetype": "application/pdf",
+                    "lang": "pt",
+                    "data": [
+                        {
+                            "timestamp": "2018-08-05T23:30:43.491793Z",
+                            "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-v2-pt.pdf",
+                            "size_bytes": 123456,
+                        }
+                    ],
+                },
+                {
+                    "filename": "0034-8910-rsp-48-2-0275-v2-en.pdf",
+                    "mimetype": "application/pdf",
+                    "lang": "en",
+                    "data": [
+                        {
+                            "timestamp": "2018-08-05T23:30:50.271593Z",
+                            "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-v2-en.pdf",
+                            "size_bytes": 123456,
+                        },
+                        {
+                            "timestamp": "2018-08-06T09:30:23.431397Z",
+                            "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-v2-2-en.pdf",
+                            "size_bytes": 123456,
+                        },
+                    ],
+                },
+            ],
         },
     ],
 }
@@ -123,6 +202,7 @@ class DocumentTests(unittest.TestCase):
                 "0034-8910-rsp-48-2-0275-gf01.gif": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-gf01.gif"
             },
             "timestamp": "2018-08-05T23:02:29.392990Z",
+            "renditions": [],
         }
         self.assertEqual(oldest, expected)
 
@@ -144,6 +224,7 @@ class DocumentTests(unittest.TestCase):
                             ),
                         ]
                     },
+                    "renditions": [],
                 }
             ],
         }
@@ -176,6 +257,7 @@ class DocumentTests(unittest.TestCase):
                 "0034-8910-rsp-48-2-0275-gf01.gif": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-gf01.gif"
             },
             "timestamp": "2018-08-05T23:30:29.392990Z",
+            "renditions": [],
         }
         self.assertEqual(target, expected)
 
@@ -188,6 +270,7 @@ class DocumentTests(unittest.TestCase):
                 "0034-8910-rsp-48-2-0275-gf01.gif": "/rawfiles/8e644999a8fa4/0034-8910-rsp-48-2-0275-gf01.gif"
             },
             "timestamp": "2018-08-05T23:02:29.392990Z",
+            "renditions": [],
         }
         self.assertEqual(target, expected)
 
@@ -198,6 +281,7 @@ class DocumentTests(unittest.TestCase):
             "data": "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275.xml",
             "assets": {"0034-8910-rsp-48-2-0275-gf01.gif": ""},
             "timestamp": "2018-08-05T23:02:29.392990Z",
+            "renditions": [],
         }
         self.assertEqual(target, expected)
 
@@ -209,6 +293,129 @@ class DocumentTests(unittest.TestCase):
         document = self.make_one()
         self.assertRaises(
             ValueError, lambda: document.version_at("2018-08-05 23:03:44")
+        )
+
+    def test_add_new_rendition(self):
+        document = self.make_one()
+        self.assertEqual(len(document.version()["renditions"]), 0)
+
+        document.new_rendition_version(
+            "0034-8910-rsp-48-2-0275-en.pdf",
+            "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-en.pdf",
+            "application/pdf",
+            "en",
+            798765,
+        )
+        self.assertEqual(len(document.version()["renditions"]), 1)
+        self.assertEqual(
+            document.version()["renditions"][0]["filename"],
+            "0034-8910-rsp-48-2-0275-en.pdf",
+        )
+
+    def test_add_second_rendition_version(self):
+        document = self.make_one()
+        self.assertEqual(len(document.version()["renditions"]), 0)
+
+        document.new_rendition_version(
+            "0034-8910-rsp-48-2-0275-en.pdf",
+            "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-en.pdf",
+            "application/pdf",
+            "en",
+            798765,
+        )
+        document.new_rendition_version(
+            "0034-8910-rsp-48-2-0275-en.pdf",
+            "/rawfiles/5cb5f9b2691cd/0034-8910-rsp-48-2-0275-en.pdf",
+            "application/pdf",
+            "en",
+            788523,
+        )
+        self.assertEqual(len(document.version()["renditions"]), 1)
+        self.assertEqual(
+            document.version()["renditions"][0]["filename"],
+            "0034-8910-rsp-48-2-0275-en.pdf",
+        )
+        self.assertEqual(document.version()["renditions"][0]["size_bytes"], 788523)
+        self.assertEqual(
+            document.version()["renditions"][0]["url"],
+            "/rawfiles/5cb5f9b2691cd/0034-8910-rsp-48-2-0275-en.pdf",
+        )
+
+    def test_add_new_rendition_raises_if_already_set(self):
+        document = self.make_one()
+        self.assertEqual(len(document.version()["renditions"]), 0)
+
+        document.new_rendition_version(
+            "0034-8910-rsp-48-2-0275-en.pdf",
+            "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-en.pdf",
+            "application/pdf",
+            "en",
+            798765,
+        )
+        self.assertEqual(len(document.version()["renditions"]), 1)
+        self.assertRaises(
+            exceptions.VersionAlreadySet,
+            document.new_rendition_version,
+            "0034-8910-rsp-48-2-0275-en.pdf",
+            "/rawfiles/7ca9f9b2687cb/0034-8910-rsp-48-2-0275-en.pdf",
+            "application/pdf",
+            "en",
+            798765,
+        )
+
+    def test_get_latest_renditions_of_latest_version(self):
+        expected = [
+            {
+                "filename": "0034-8910-rsp-48-2-0275-v2-pt.pdf",
+                "mimetype": "application/pdf",
+                "lang": "pt",
+                "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-v2-pt.pdf",
+                "size_bytes": 123456,
+            },
+            {
+                "filename": "0034-8910-rsp-48-2-0275-v2-en.pdf",
+                "mimetype": "application/pdf",
+                "lang": "en",
+                "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-v2-2-en.pdf",
+                "size_bytes": 123456,
+            },
+        ]
+        document = domain.Document(manifest=SAMPLE_MANIFEST_WITH_RENDITIONS)
+        self.assertEqual(document.version()["renditions"], expected)
+
+    def test_get_renditions_of_a_given_version(self):
+        expected = [
+            {
+                "filename": "0034-8910-rsp-48-2-0275-pt.pdf",
+                "mimetype": "application/pdf",
+                "lang": "pt",
+                "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-pt.pdf",
+                "size_bytes": 123456,
+            }
+        ]
+        document = domain.Document(manifest=SAMPLE_MANIFEST_WITH_RENDITIONS)
+        self.assertEqual(document.version(index=0)["renditions"], expected)
+
+    def test_get_renditions_of_a_given_version_by_timestamp(self):
+        expected = [
+            {
+                "filename": "0034-8910-rsp-48-2-0275-v2-pt.pdf",
+                "mimetype": "application/pdf",
+                "lang": "pt",
+                "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-v2-pt.pdf",
+                "size_bytes": 123456,
+            },
+            {
+                "filename": "0034-8910-rsp-48-2-0275-v2-en.pdf",
+                "mimetype": "application/pdf",
+                "lang": "en",
+                "url": "/rawfiles/bf139b9aa3066/0034-8910-rsp-48-2-0275-v2-en.pdf",
+                "size_bytes": 123456,
+            },
+        ]
+        document = domain.Document(manifest=SAMPLE_MANIFEST_WITH_RENDITIONS)
+        self.assertEqual(
+            document.version_at("2018-08-05T23:40:00Z")["renditions"], expected
         )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Estas modificações visam tornar possível e registro e recuperação dos PDFs e outras manifestações junto ao arquivo XML.

#### Onde a revisão poderia começar?
Acredito que na modelagem de dados, no módulo `documentstore/domain.py`.

#### Como este poderia ser testado manualmente?
1. Registre um documento:
```bash
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347 -d '{"data": "https://raw.githubusercontent.com/scieloorg/packtools/master/tests/samples/0034-8910-rsp-48-2-0347.xml", "assets": [{"asset_id":"0034-8910-rsp-48-2-0347-gf01", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf01-en", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf02", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf02-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf03", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf03.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf03-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf03-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf04", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf04.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf04-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf04-en.jpg"}]}'
```

2. Associe uma manifestação na versão mais recente do documento:
```bash
curl -v -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347/renditions -d '{"filename": "en_1678-4464-csp-35-05-e00073619.pdf", "data_url": "http://www.scielo.br/pdf/csp/v35n5/en_1678-4464-csp-35-05-e00073619.pdf", "mimetype": "application/pdf", "lang": "en", "size_bytes": 234569}'
```
 
3. Acesse a lista de manifestações da versão mais recente do documento:
```bash
curl -v http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347/renditions
```

#### Algum cenário de contexto que queira dar?
Identifiquei que após a mudança, os dados retornados pelo endpoint `assets` passaram a entregar também as manifestações. Este efeito colateral não é desejado mas, por conta do baixo impacto, preferi deixar para a refatoração do endpoint, que deverá acontecer em breve.

#### Quais são tickets relevantes?
#1 