### PR TITLE
Altera servidor WSGI para Waitress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apk add --no-cache --virtual .build-deps \
         make gcc libxml2-dev libxslt-dev musl-dev g++ \
     && apk add libxml2 libxslt \
     && pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir gunicorn \
     && pip install --no-cache-dir raven \
     && pip install --no-cache-dir -r requirements.txt \
     && pip install --no-index --find-links=file:///deps -U scielo-documentstore \

--- a/production.ini
+++ b/production.ini
@@ -11,14 +11,12 @@ pyramid.default_locale_name = en
 ;kernel.app.mongodb.dsn =
 
 [server:main]
-use = egg:gunicorn#main
+use = egg:waitress#main
 host = 0.0.0.0
 port = 6543
-workers = 2
-threads = 2
-preload = true
-reload = true
-loglevel = info
+;threads = 4
+;outbuf_overflow = 1048576 #(1MB)
+;inbuf_overflow = 524288 #(512K)
 
 # Begin logging configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ translationstring==1.3
 Unidecode==1.0.22
 urllib3==1.23
 venusian==1.1.0
-waitress==1.1.0
+waitress==1.3.0
 WebOb==1.8.2
 zope.deprecation==4.3.0
 zope.interface==4.5.0

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
         "colander",
         "python-slugify",
         "scielo-clea>=0.3.0",
+        "waitress",
     ],
     test_suite="tests",
     classifiers=(


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request altera o servidor WSGI a ser utilizado pela aplicação nas imagens Docker e na configuração de produção. A justificativa pode ser encontrada no ticket #151.

#### Onde a revisão poderia começar?
No arquivo de configurações `production.ini`.

#### Como este poderia ser testado manualmente?
Construindo e executando a imagem Docker ou subindo a aplicação com o comando `pserve`.

#### Algum cenário de contexto que queira dar?
A justificativa pode ser encontrada no ticket #151, mas em resumo o objetivo é tornar o comportamento da aplicação mais previsível, em termos de escalabilidade, evitando que um número excessivo de conexões ao banco de dados sejam abertas simultaneamente, exaurindo os recursos disponíveis. O design híbrido sync-async do Waitress garante o atendimento de um grande número de requisições concorrentes, mas sem abrir mão da previsibilidade e controle do consumo de recursos. 

Outro ponto relevante é que será possível utilizar o Prometheus com o mínimo de fricção, haja vista que a sua lib para Python não funciona bem com múltiplos processos. 

#### Quais são tickets relevantes?
#151

### Referências
* https://docs.pylonsproject.org/projects/waitress/en/v1.2.0/design.html
* https://github.com/etianen/django-herokuapp/issues/9
