### PR TITLE
Altera a semântica do argumento `since`

### DIFF
--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -169,7 +169,7 @@ class ChangesStore(interfaces.ChangesDataStore):
 
     def filter(self, since: str = "", limit: int = 500):
         return self._collection.find(
-            {"_id": {"$gte": since}},
+            {"_id": {"$gt": since}},
             sort=[("_id", pymongo.ASCENDING)],
             projection={"_id": False},
         ).limit(limit)

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -191,7 +191,7 @@ class InMemoryChangesDataStore(interfaces.ChangesDataStore):
         return [
             change
             for timestamp, change in self._data_store.items()
-            if timestamp >= since
+            if timestamp > since
         ][:limit]
 
 
@@ -208,11 +208,11 @@ class MongoDBCollectionStub:
             self._mongo_store[data["_id"]] = data
 
     def find(self, query, sort=None, projection=None):
-        since = query["_id"]["$gte"]
+        since = query["_id"]["$gt"]
 
         first = 0
         for i, change_key in enumerate(self._mongo_store):
-            if self._mongo_store[change_key]["_id"] < since:
+            if self._mongo_store[change_key]["_id"] <= since:
                 continue
             else:
                 first = i

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -315,7 +315,7 @@ class ChangesStoreTestMixin:
             store.add(change)
 
         self.assertEqual(
-            list(store.filter(since="2018-08-05T23:03:47.891432Z")), changes[1:]
+            list(store.filter(since="2018-08-05T23:03:47.891432Z")), changes[2:]
         )
 
     def test_filter_limit(self):

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -344,7 +344,7 @@ class FetchChangeUnitTest(unittest.TestCase):
         since = restfulapi.fetch_changes(self.request)["results"][5]["timestamp"]
         self.request.GET["since"] = since
 
-        self.assertEqual(len(restfulapi.fetch_changes(self.request)["results"]), 5)
+        self.assertEqual(len(restfulapi.fetch_changes(self.request)["results"]), 4)
 
     def test_since_must_return_empty_result_list_with_unknown_value(self):
         self.make_documents(5)
@@ -361,7 +361,7 @@ class FetchChangeUnitTest(unittest.TestCase):
         self.request.GET["limit"] = 5
 
         self.assertEqual(
-            restfulapi.fetch_changes(self.request)["results"], changes[10:15]
+            restfulapi.fetch_changes(self.request)["results"], changes[11:16]
         )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Altera a semântica do argumento `since`, da API de mudanças. Após a modificação, os resultados retornados serão os com o timestamp maior que o informado no argumento `since`, e não maior ou igual como anteriormente.

A justificativa completa está no ticket #135.

#### Onde a revisão poderia começar?
`documentstore/adapters.py`

#### Como este poderia ser testado manualmente?
Inicie uma instância local, registre alguns documentos e em seguida acesse o endpoint `/changes`. Passe como argumento `since` o timestamp da primeira mudança, observe que a mudança subsequente deverá ser a primeira da lista de resultados. Repita o processo. Passe um valor bastante anterior (100 anos atrás), e observe que a lista conterá todos os resultados. Para finalizar, passe um valor futuro (daqui 100 anos, por exemplo), e observe que a lista de resultados aparecerá vazia.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#135 

### Referências
n/a
