### PR TITLE
Adiciona suporte a exclusão de documentos

### DIFF
--- a/documentstore/exceptions.py
+++ b/documentstore/exceptions.py
@@ -27,3 +27,9 @@ class VersionAlreadySet(RetryableError):
     """Erro que representa a tentativa de definir uma nova versão idêntica a 
     anterior. 
     """
+
+
+class DeletedVersion(NonRetryableError):
+    """Erro que representa a tentativa de recuperar o XML de um documento
+    em uma versão que foi excluída.
+    """

--- a/documentstore/pyramid_prometheus.py
+++ b/documentstore/pyramid_prometheus.py
@@ -48,7 +48,9 @@ def tween_factory(handler, registry):
             )
             if response:
                 RESPONSE_SIZE_BYTES.labels(route_pattern).observe(
+                    # content_length é None em casos de exceção
                     response.content_length
+                    or 0
                 )
             REQUESTS_INPROGRESS.dec()
 

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -795,3 +795,25 @@ class RegisterDocumentVersionUnitTests(unittest.TestCase):
         )
         response = restfulapi.register_rendition_version(request)
         self.assertIsInstance(response, HTTPNoContent)
+
+
+class DeleteDocumentUnitTests(unittest.TestCase):
+    def test_when_doesnt_exist_returns_http_404(self):
+        request = make_request()
+        request.matchdict = {"document_id": "unknown"}
+        request.services["delete_document"] = Mock(side_effect=exceptions.DoesNotExist)
+        self.assertRaises(HTTPNotFound, restfulapi.delete_document, request)
+
+    def test_when_already_deleted_returns_HTTPNoContent(self):
+        request = make_request()
+        request.matchdict = {"document_id": "unknown"}
+        request.services["delete_document"] = Mock(
+            side_effect=exceptions.VersionAlreadySet
+        )
+        self.assertRaises(HTTPNoContent, restfulapi.delete_document, request)
+
+    def test_returns_HTTPNoContent_on_success(self):
+        request = make_request()
+        request.matchdict = {"document_id": "unknown"}
+        request.services["delete_document"] = Mock()
+        self.assertRaises(HTTPNoContent, restfulapi.delete_document, request)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona suporte a exclusão de documentos

A exclusão é representada pela inclusão de uma nova versão do documento
indicando que o mesmo foi excluído, por meio da chave `deleted=True`.
Também é armazenado o timestamp da exclusão.

Essa estrutura de dados é retornada pelos métodos `version` e
`version_at` quando tratar-se de uma versão excluída. Os métodos `data`,
`new_rendition_version` e `new_asset_version` levantam a exceção
`exceptions.DeletedVersion`.

O endpoint RESTFul passa a retornar o código *410 Gone* ao tentar
recuperar documentos excluídos. Foi decidido retornar esse código para
desambiguar documentos excluídos dos que nunca existiram.

#### Onde a revisão poderia começar?
Acredito que pelo módulo `restfulapi.py`. 

#### Como este poderia ser testado manualmente?

Com a instância rodando, registre um novo documento:
```bash
$ curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347 -d '{"data": "https://raw.githubusercontent.com/scieloorg/packtools/master/tests/samples/0034-8910-rsp-48-2-0347.xml", "assets": [{"asset_id":"0034-8910-rsp-48-2-0347-gf01", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf01-en", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf02", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf02-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf03", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf03.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf03-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf03-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf04", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf04.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf04-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf04-en.jpg"}]}'
```

Observe que seu XML é retornado:
```bash
$ curl 'http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347'
```

Exclua o documento:
```bash
$ curl -X DELETE 'http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347'
```

Observe que o código HTTP *410 Gone* é retornado:
```bash
$ curl -v 'http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347'
```

Observe o registro no endpoint de mudanças:
```bash
$ curl 'http://0.0.0.0:6543/changes'
```
#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/document-store/issues/156

### Referências
* https://httpstatuses.com/410
