### PR TITLE
Especializa respostas da API RESTfull e implementa atualização em massa de relacionamentos

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -10,6 +10,7 @@ from pyramid.httpexceptions import (
     HTTPCreated,
     HTTPBadRequest,
     HTTPGone,
+    HTTPUnprocessableEntity,
 )
 from cornice import Service
 from cornice.validators import colander_body_validator
@@ -290,6 +291,13 @@ class JournalIssuesSchema(colander.MappingSchema):
 
     issue = colander.SchemaNode(colander.String())
     index = colander.SchemaNode(colander.Int(), missing=colander.drop)
+
+
+class JournalIssuesReplaceSchema(colander.SequenceSchema):
+    """Representa o schema de dados utilizado durante a atualização
+    da lista completa de fascículos de um periódico"""
+
+    issue = colander.SchemaNode(colander.String())
 
 
 class DeleteJournalIssuesSchema(colander.MappingSchema):
@@ -793,6 +801,36 @@ def patch_journal_issues(request):
         return HTTPNoContent("issue added to journal successfully.")
     else:
         return HTTPNoContent("issue added to journal successfully.")
+
+
+@journal_issues.put(
+    schema=JournalIssuesReplaceSchema(),
+    validators=(colander_body_validator,),
+    response_schemas={
+        "204": JournalIssuesReplaceSchema(
+            description="Lista de fascículos atualizada com sucesso"
+        ),
+        "422": JournalIssuesReplaceSchema(
+            description="Erro ao atualizar a lista de issues. Payload com conteúdo inválido."
+        ),
+        "404": JournalIssuesReplaceSchema(description="Periódico não encontrado"),
+    },
+    accept="application/json",
+    renderer="json",
+)
+def put_journal_issues(request):
+    try:
+        request.services["update_issues_in_journal"](
+            id=request.matchdict["journal_id"], issues=request.validated
+        )
+    except exceptions.DoesNotExist as exc:
+        return HTTPNotFound(str(exc))
+    except exceptions.AlreadyExists as exc:
+        return HTTPUnprocessableEntity(
+            explanation="cannot process the request with duplicated items."
+        )
+
+    return HTTPNoContent("issues list updated successfully.")
 
 
 @journals_aop.patch(


### PR DESCRIPTION
#### O que esse PR faz?
Este PR tem o propósito de implementar `parte` da solução exigida pela issue #163. Foi implementada a atualização em `lote` da lista de issues de um `journal`.

#### Onde a revisão poderia começar?
- `documentstore/services.py` L: `360`
- `documentstore/restfulapi.py` L: `860`
#### Como este poderia ser testado manualmente?

1. Criar um journal;
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/example  -d  '{"title": "journal-example"}'
```

2.  Enviar um PUT com uma lista de `issues`;
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/example/issues -d '["jligwbsvcfakvoapacjvfec", "ndqbgyrmopjtdkiruviwadk"]' -v
```

3. Verificar que o código de status é  `204`;

4. Verificar que as issues realmente foram atualizadas no registro do `journal`;
```shell
curl -X GET -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/example
```

5. Enviar uma PUT para zerar a lista de issues e verificar que o código de status é `204`
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/example/issues -d '[]' -v
```

6. Enviar um PUT com itens duplicados
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/example/issues -d '["a", "a"]' -v
```
7. Verificar que não houve atualização da lista de itens e que o status de status é `422`;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#163 

### Referências
[RFC HTTP - 422](https://tools.ietf.org/html/rfc4918#section-11.2)
[Código de resposta para dados inválidos](https://www.bennadel.com/blog/2434-http-status-codes-for-invalid-data-400-vs-422.htm)
[Response code for invalid data](https://stackoverflow.com/questions/6123425/rest-response-code-for-invalid-data)
