### PR TITLE
Criação dos  Endpoint RESTful para adicionar documentos aos bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ nosetests.xml
 
 # Local app
 datadir
+.DS_Store

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -74,7 +74,7 @@ bundles = Service(
 bundles_documents = Service(
     name="bundles_documents",
     path="/bundles/{bundle_id}/documents",
-    description="Documents updation to documents bundle.",
+    description="Update documents of documents bundle.",
 )
 
 changes = Service(


### PR DESCRIPTION
#### O que esse PR faz?
Este PR tem o propósito de implementar o endpoint exigido pela issue #154. Foi implementada a atualização em `lote` da lista de documentos de um `document-bundle`.

#### Onde a revisão poderia começar?
Os arquivos mais sensíveis para a implementação soa:
* `documentstore/restfulapi.py`
* `documentstore/services.py`

Testes
* `tests/test_restfulapi.py`
* `tests/test_services.py`

#### Como este poderia ser testado manualmente?

1. Criar um issue;
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/example  -d  '{"title": "issue-example"}'
```
2.  Enviar um PUT com uma lista de `docs`;
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/example/documents -d '["jligwbsvcfakvoapacjvfec", "ndqbgyrmopjtdkiruviwadk"]' -v
```
3. Verificar que o código de status é  `204`;
4. Verificar que os documentos realmente foram atualizados no registro da `issue`;
```shell
curl -X GET -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/example
```
5. Enviar uma PUT para zerar a lista de documents e verificar que o código de status é `204`
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/example/documents -d '[]' -v
```
6. Enviar um PUT com itens duplicados
```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/example/documents -d '["a", "a"]' -v
```

#### Algum cenário de contexto que queira dar?
N/A

#### Quais são tickets relevantes?
#154 

### Referências
#163 
