### PR TITLE
Atualizar a versão do `scielo-clea`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pytz==2018.6
 regex==2018.8.29
 repoze.lru==0.7
 requests==2.20.0
-scielo-clea==0.3.0
+scielo-clea==0.4.0
 simplejson==3.16.0
 six==1.11.0
 translationstring==1.3


### PR DESCRIPTION
#### O que esse PR faz?
Atualizar a versão do `scielo-clea`, como descrito no Tk #172 

#### Onde a revisão poderia começar?
So foi alterado o arquivo `requirements.txt`

#### Como este poderia ser testado manualmente?
Apos atualizar o ambinete ou refazer o build da docker, as funções do document-store não deve ser alteradas, e pelo contrario, algums problemas na leitura do xml devem ser corrigidos 

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#172  scieloorg/clea#3

### Referências
Resposta original do @danilobellini in scieloorg/clea#3 (comment)
