### PR TITLE
Adequa a remoção de itens do BundleManifest

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -638,16 +638,20 @@ class BundleManifest:
 
     @staticmethod
     def remove_item(
-        items_bundle: dict, item: str, now: Callable[[], str] = utcnow
+        bundle: dict, item_id: str, now: Callable[[], str] = utcnow
     ) -> dict:
-        if item not in items_bundle["items"]:
+
+        item = BundleManifest.get_item(bundle, item_id)
+
+        if item is None:
             raise exceptions.DoesNotExist(
-                'cannot remove item "%s" from bundle: ' "the item does not exist" % item
+                "cannot remove item from bundle: "
+                'the item id "%s" does not exist' % item_id
             )
-        _items_bundle = deepcopy(items_bundle)
-        _items_bundle["items"].remove(item)
-        _items_bundle["updated"] = now()
-        return _items_bundle
+        _bundle = deepcopy(bundle)
+        _bundle["items"].remove(item)
+        _bundle["updated"] = now()
+        return _bundle
 
     @staticmethod
     def set_component(

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -801,7 +801,7 @@ class BundleManifestTest(UnittestMixin, unittest.TestCase):
             documents_bundle, "/documents/0034-8910-rsp-48-2-0475"
         )
         self.assertNotIn(
-            "/documents/0034-8910-rsp-48-2-0475", documents_bundle["items"]
+            {"id": "/documents/0034-8910-rsp-48-2-0475"}, documents_bundle["items"]
         )
         self.assertTrue(current_updated < documents_bundle["updated"])
 
@@ -811,8 +811,8 @@ class BundleManifestTest(UnittestMixin, unittest.TestCase):
         current_item_len = len(documents_bundle["items"])
         self._assert_raises_with_message(
             exceptions.DoesNotExist,
-            'cannot remove item "/documents/0034-8910-rsp-48-2-0775" from bundle: '
-            "the item does not exist",
+            "cannot remove item from bundle: "
+            'the item id "/documents/0034-8910-rsp-48-2-0775" does not exist',
             domain.BundleManifest.remove_item,
             documents_bundle,
             "/documents/0034-8910-rsp-48-2-0775",
@@ -1061,18 +1061,23 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
         documents_bundle.add_document({"id": "/documents/0034-8910-rsp-48-2-0277"})
         documents_bundle.remove_document("/documents/0034-8910-rsp-48-2-0275")
         self.assertNotIn(
-            "/documents/0034-8910-rsp-48-2-0275", documents_bundle.manifest["items"]
+            {"id": "/documents/0034-8910-rsp-48-2-0275"},
+            documents_bundle.manifest["items"],
         )
         self.assertEqual(2, len(documents_bundle.manifest["items"]))
 
     def test_remove_document_raises_exception_if_item_does_not_exist(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.add_document("/documents/0034-8910-rsp-48-2-0276")
-        documents_bundle.add_document("/documents/0034-8910-rsp-48-2-0277")
+        documents_bundle.add_document(
+            {"id": "/documents/0034-8910-rsp-48-2-0276", "order": 4}
+        )
+        documents_bundle.add_document(
+            {"id": "/documents/0034-8910-rsp-48-2-0277", "order": 2}
+        )
         self._assert_raises_with_message(
             exceptions.DoesNotExist,
-            'cannot remove item "/documents/0034-8910-rsp-48-2-0275" from bundle: '
-            "the item does not exist",
+            "cannot remove item from bundle: "
+            'the item id "/documents/0034-8910-rsp-48-2-0275" does not exist',
             documents_bundle.remove_document,
             "/documents/0034-8910-rsp-48-2-0275",
         )
@@ -1921,8 +1926,8 @@ class JournalTest(UnittestMixin, unittest.TestCase):
         journal = domain.Journal(id="0034-8910-rsp")
         self._assert_raises_with_message(
             exceptions.DoesNotExist,
-            'cannot remove item "0034-8910-rsp-48-2" from bundle: '
-            "the item does not exist",
+            "cannot remove item from bundle: "
+            'the item id "0034-8910-rsp-48-2" does not exist',
             journal.remove_issue,
             "0034-8910-rsp-48-2",
         )


### PR DESCRIPTION
#### O que esse PR faz?
Este PR mantém a compatibilidade durante a remoção de itens de um Bundle. A verificação continua sendo feito a partir de um `id` mas a remoção é feita a partir do item completo.

#### Onde a revisão poderia começar?
- `documentstore/domain.py` L: `640`

#### Como este poderia ser testado manualmente?
Para testar este PR manualmente deve-se:
1. Iniciar uma instância interativa do python;
2. Importar o domínio do `kernel`;
3. Instanciar BundleManifest; 
4. Adicione um item ao bundle;
5. Remova um item do bundle;

```python
bundle = BundleManifest.new(bundle_id="bundle-1")                                                                                                                                                                                    
bundle = BundleManifest.add_item(bundle, item={"id": "item-1"})                                                                                                                                                                      
bundle = BundleManifest.remove_item(bundle, item_id="item-1")   
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #169 

### Referências
N/A
