### PR TITLE
Adequa a interface RESTful para usar a nova estrutura de itens ao relacionar entidades

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -240,7 +240,10 @@ class DocumentsBundleDocumentsReplaceSchema(colander.SequenceSchema):
     """Representa o schema de dados para registro o relacionamento de documento no 
     Documents Bundle."""
 
-    docs = colander.SchemaNode(colander.String())
+    @colander.instantiate(missing=colander.drop)
+    class document(colander.MappingSchema):
+        id = colander.SchemaNode(colander.String())
+        order = colander.SchemaNode(colander.String())
 
 
 class QueryChangeSchema(colander.MappingSchema):

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -298,11 +298,22 @@ class FrontDocumentSchema(colander.MappingSchema):
     data = colander.SchemaNode(colander.String(), missing=colander.drop)
 
 
+class JournalIssueItem(colander.MappingSchema):
+    """Schema que representa uma Issue como item a ser relacionado
+    com um Journal"""
+
+    id = colander.SchemaNode(colander.String())
+
+    @colander.instantiate()
+    class ns(colander.SequenceSchema):
+        item = colander.SchemaNode(colander.String())
+
+
 class JournalIssuesSchema(colander.MappingSchema):
     """Representa o schema de dados de atualização de fascículos de periódico.
     """
 
-    issue = colander.SchemaNode(colander.String())
+    issue = JournalIssueItem()
     index = colander.SchemaNode(colander.Int(), missing=colander.drop)
 
 
@@ -310,7 +321,7 @@ class JournalIssuesReplaceSchema(colander.SequenceSchema):
     """Representa o schema de dados utilizado durante a atualização
     da lista completa de fascículos de um periódico"""
 
-    issue = colander.SchemaNode(colander.String())
+    issue = JournalIssueItem()
 
 
 class DeleteJournalIssuesSchema(colander.MappingSchema):

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -312,32 +312,32 @@ class PutDocumentsBundleDocumentTest(unittest.TestCase):
 
     def test_should_call_update_documents_in_issues(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = ["doc-1", "doc-2"]
+        self.request.validated = [{"id": "doc-1"}, {"id": "doc-2"}]
         MockUpdateDocumentsInIssues = Mock()
         self.request.services[
             "update_documents_in_documents_bundle"
         ] = MockUpdateDocumentsInIssues
         restfulapi.put_bundles_documents(self.request)
         MockUpdateDocumentsInIssues.assert_called_once_with(
-            id="example-bundle-id", docs=["doc-1", "doc-2"]
+            id="example-bundle-id", docs=[{"id": "doc-1"}, {"id": "doc-2"}]
         )
 
     def test_should_return_422_if_already_exists_exception_is_raised(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = ["doc-1", "doc-1"]
+        self.request.validated = [{"id": "doc-1"}, {"id": "doc-1"}]
         response = restfulapi.put_bundles_documents(self.request)
         self.assertIsInstance(response, HTTPUnprocessableEntity)
 
     def test_should_not_update_if_already_exists_exception_is_raised(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = ["doc-1", "doc-1"]
+        self.request.validated = [{"id": "doc-1"}, {"id": "doc-1"}]
         restfulapi.put_bundles_documents(self.request)
         response = restfulapi.fetch_documents_bundle(self.request)
         self.assertEqual([], response.get("items"))
 
     def test_should_return_404_if_bundle_not_found(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = ["doc-1"]
+        self.request.validated = [{"id": "doc-1"}]
         MockUpdateDocumentsInIssues = Mock(
             side_effect=exceptions.DoesNotExist("Does Not Exist")
         )
@@ -349,7 +349,7 @@ class PutDocumentsBundleDocumentTest(unittest.TestCase):
 
     def test_should_return_204_if_bundle_issues_was_updated(self):
         self.request.matchdict["bundle_id"] = "example-bundle-id"
-        self.request.validated = ["doc-1"]
+        self.request.validated = [{"id": "doc-1"}]
         response = restfulapi.put_bundles_documents(self.request)
         self.assertIsInstance(response, HTTPNoContent)
 

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -506,7 +506,7 @@ class PatchJournalUnitTest(unittest.TestCase):
 
 class JournalIssuesSchemaTest(unittest.TestCase):
     def test_index_field_is_optional(self):
-        data = {"issue": "1678-4596-cr-25-3"}
+        data = {"issue": {"id": "1678-4596-cr-25-3", "ns": []}}
         restfulapi.JournalIssuesSchema().deserialize(data)
 
     def test_issue_field_is_required(self):
@@ -523,7 +523,7 @@ class JournalIssuesSchemaTest(unittest.TestCase):
                 )
 
     def test_valid(self):
-        data = {"issue": "1678-4596-cr-25-3", "index": 10}
+        data = {"issue": {"id": "1678-4596-cr-25-3", "ns": []}, "index": 10}
         restfulapi.JournalIssuesSchema().deserialize(data)
 
 
@@ -623,30 +623,40 @@ class PutJournalIssuesTest(unittest.TestCase):
 
     def test_should_call_update_issues_in_journal(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = ["issue-1", "issue-2"]
+        self.request.validated = [
+            {"id": "issue-1", "ns": []},
+            {"id": "issue-2", "ns": []},
+        ]
         MockUpdateIssuesInJournal = Mock()
         self.request.services["update_issues_in_journal"] = MockUpdateIssuesInJournal
         restfulapi.put_journal_issues(self.request)
         MockUpdateIssuesInJournal.assert_called_once_with(
-            id="example-journal-id", issues=["issue-1", "issue-2"]
+            id="example-journal-id",
+            issues=[{"id": "issue-1", "ns": []}, {"id": "issue-2", "ns": []}],
         )
 
     def test_should_return_422_if_already_exists_exception_is_raised(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = ["issue-1", "issue-1"]
+        self.request.validated = [
+            {"id": "issue-1", "ns": []},
+            {"id": "issue-1", "ns": []},
+        ]
         response = restfulapi.put_journal_issues(self.request)
         self.assertIsInstance(response, HTTPUnprocessableEntity)
 
     def test_should_not_update_if_already_exists_exception_is_raised(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = ["issue-1", "issue-1"]
+        self.request.validated = [
+            {"id": "issue-1", "ns": []},
+            {"id": "issue-1", "ns": []},
+        ]
         restfulapi.put_journal_issues(self.request)
         response = restfulapi.get_journal(self.request)
         self.assertEqual([], response.get("items"))
 
     def test_should_return_404_if_journal_not_found(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = ["issue-1"]
+        self.request.validated = [{"id": "issue-1", "ns": []}]
         MockUpdateIssuesInJournal = Mock(
             side_effect=exceptions.DoesNotExist("Does Not Exist")
         )
@@ -656,7 +666,7 @@ class PutJournalIssuesTest(unittest.TestCase):
 
     def test_should_return_204_if_journal_issues_was_updated(self):
         self.request.matchdict["journal_id"] = "example-journal-id"
-        self.request.validated = ["issue-1"]
+        self.request.validated = [{"id": "issue-1", "ns": []}]
         response = restfulapi.put_journal_issues(self.request)
         self.assertIsInstance(response, HTTPNoContent)
 


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request finaliza as modificações relacionadas a lista de itens dos `bundles`. O relacionamento entre Journal -> Issue e Issue -> Document passa a receber itens na estrutura de dicionários e sempre exige a chave `id`.

#### Onde a revisão poderia começar?
- `documentstore/restfulapi.py` L `243`
- `documentstore/restfulapi.py` L `304`

#### Como este poderia ser testado manualmente?
A sugestão para testar este PR é utilizar todos os endpoints expostos pelo Kernel e que em algum nível possam enfrentar problemas pelas modificações:

Alguns comandos para ajudar:

```shell
# DOCUMENTS

# Crie um documento
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347 -d '{"data": "https://raw.githubusercontent.com/scieloorg/packtools/master/tests/samples/0034-8910-rsp-48-2-0347.xml", "assets": [{"asset_id":"0034-8910-rsp-48-2-0347-gf01", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf01-en", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf01-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf02", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf02-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf02-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf03", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf03.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf03-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf03-en.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf04", "asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf04.jpg"},{"asset_id":"0034-8910-rsp-48-2-0347-gf04-en","asset_url":"http://www.scielo.br/img/revistas/rsp/v48n2/0034-8910-rsp-48-2-0347-gf04-en.jpg"}]}'

# Acesse o documento
curl -X GET -H 'Accept: text/xml' http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347 -v | more

# Acesse o manifest e o front
curl -X GET -H 'Accept: application/json' http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347/manifest -v | more

curl -X GET -H 'Accept: application/json' http://0.0.0.0:6543/documents/0034-8910-rsp-48-2-0347/front -v | more

# BUNDLES

# Crie um bundle
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/0066-782X-1999-v72-n0 -d '{"titles": [{"language": "pt", "value": "Bundle exemplo"}], "volume": "v1"}'

# Acesse o bundle
curl -X GET -H 'Accept: application/json' http://0.0.0.0:6543/bundles/0066-782X-1999-v72-n0 -v | more

# Relacione o documento com o bundle
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/0066-782X-1999-v72-n0/documents -d '[{"id": "0034-8910-rsp-48-2-0347", "order": "01"}, {"id": "0034-8910-rsp-48-2-0348", "order": "02"}]' -v

# Verifique se o relacionamento foi realizado
curl -X GET -H 'Accept: application/json' http://0.0.0.0:6543/bundles/0066-782X-1999-v72-n0 -v


# JOURNALS

# Crie um journal
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX -d '{"title": "Exemplo de journal"}'

# Relacione com um bundle criado
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX/issues -d '[{"id": "0066-782X-1999-v72-n0", "ns": ["2019", "v1"]}]' -v

# Acesse o journal e verifique o relacionamwento
curl -X GET -H 'Accept: application/json' http://0.0.0.0:6543/journals/0066-782XX -v

# Tente alterar UM relacionamento e perceba que não é possível via PATCH
curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX/issues -d '{"issue": {"id": "0066-782X-1999-v72-n0", "ns": ["2019", "v2"]}}'

# Adicione uma relacionamento em uma posição específica via PATCH
curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX/issues -d '{"issue": {"id": "nova-issue-2", "ns": ["2019", "v1"]}, "index": 0}'

# Remova um relacionamento
curl -X DELETE -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX/issues -d '{"issue": "nova-issue"}'
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #173 #174 

### Referências
N/A
