### PR TITLE
Adicionando atributos publication_season e publication_month ao DocumentsBundle

### DIFF
--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -35,7 +35,7 @@ SUBJECT_AREAS = (
     "Exact and Earth Sciences",
     "Health Sciences",
     "Human Sciences",
-    "Linguistics, Letters and Arts"
+    "Linguistics, Letters and Arts",
 )
 
 MAX_RETRIES = int(os.environ.get("KERNEL_LIB_MAX_RETRIES", "4"))
@@ -743,17 +743,24 @@ class DocumentsBundle:
 
     @property
     def publication_season(self):
-        return BundleManifest.get_metadata(self.manifest, "publication_season", [])
+        return BundleManifest.get_metadata(self.manifest, "publication_season", ())
 
     @publication_season.setter
-    def publication_season(self, value: List):
-        if len(value) != len(set(value)):
+    def publication_season(self, value: Tuple[int]):
+        try:
+            _value = tuple(value)
+            [int(item) for item in _value]
+            if len(set(_value)) < 2:
+                raise ValueError
+
+        except (ValueError, TypeError):
             raise ValueError(
                 "cannot set publication_season with value "
                 f'"{value}": the value is not valid'
-            )
+            ) from None
+
         self.manifest = BundleManifest.set_metadata(
-            self._manifest, "publication_season", value
+            self._manifest, "publication_season", _value
         )
 
     @property

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -743,18 +743,17 @@ class DocumentsBundle:
 
     @property
     def publication_season(self):
-        return BundleManifest.get_metadata(self.manifest, "publication_season")
+        return BundleManifest.get_metadata(self.manifest, "publication_season", [])
 
     @publication_season.setter
-    def publication_season(self, value: Union[str, int]):
-        _value = str(value)
-        if not re.match(r"^\w{3}-\w{3}$", _value):
+    def publication_season(self, value: List):
+        if len(value) != len(set(value)):
             raise ValueError(
                 "cannot set publication_season with value "
-                f'"{_value}": the value is not valid'
+                f'"{value}": the value is not valid'
             )
         self.manifest = BundleManifest.set_metadata(
-            self._manifest, "publication_season", _value
+            self._manifest, "publication_season", value
         )
 
     @property

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -726,6 +726,38 @@ class DocumentsBundle:
         )
 
     @property
+    def publication_month(self):
+        return BundleManifest.get_metadata(self.manifest, "publication_month")
+
+    @publication_month.setter
+    def publication_month(self, value: Union[str, int]):
+        _value = str(value).zfill(2)
+        if not re.match(r"^\d{2}$", _value):
+            raise ValueError(
+                "cannot set publication_month with value "
+                f'"{_value}": the value is not valid'
+            )
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "publication_month", _value
+        )
+
+    @property
+    def publication_season(self):
+        return BundleManifest.get_metadata(self.manifest, "publication_season")
+
+    @publication_season.setter
+    def publication_season(self, value: Union[str, int]):
+        _value = str(value)
+        if not re.match(r"^\w{3}-\w{3}$", _value):
+            raise ValueError(
+                "cannot set publication_season with value "
+                f'"{_value}": the value is not valid'
+            )
+        self.manifest = BundleManifest.set_metadata(
+            self._manifest, "publication_season", _value
+        )
+
+    @property
     def volume(self):
         return BundleManifest.get_metadata(self.manifest, "volume")
 

--- a/documentstore/domain.py
+++ b/documentstore/domain.py
@@ -2,7 +2,7 @@ import itertools
 from copy import deepcopy
 from io import BytesIO
 import re
-from typing import Union, Callable, Any, Tuple, List
+from typing import Union, Callable, Any, Tuple, List, Dict
 from datetime import datetime
 import time
 import os
@@ -726,42 +726,22 @@ class DocumentsBundle:
         )
 
     @property
-    def publication_month(self):
-        return BundleManifest.get_metadata(self.manifest, "publication_month")
+    def publication_months(self):
+        return BundleManifest.get_metadata(self.manifest, "publication_months", {})
 
-    @publication_month.setter
-    def publication_month(self, value: Union[str, int]):
-        _value = str(value).zfill(2)
-        if not re.match(r"^\d{2}$", _value):
-            raise ValueError(
-                "cannot set publication_month with value "
-                f'"{_value}": the value is not valid'
-            )
-        self.manifest = BundleManifest.set_metadata(
-            self._manifest, "publication_month", _value
-        )
-
-    @property
-    def publication_season(self):
-        return BundleManifest.get_metadata(self.manifest, "publication_season", ())
-
-    @publication_season.setter
-    def publication_season(self, value: Tuple[int]):
+    @publication_months.setter
+    def publication_months(self, value: Dict):
         try:
-            _value = tuple(value)
-            [int(item) for item in _value]
-            if len(set(_value)) < 2:
-                raise ValueError
-
-        except (ValueError, TypeError):
+            _value = dict(value)
+        except (TypeError, ValueError):
             raise ValueError(
-                "cannot set publication_season with value "
+                "cannot set publication_months with value "
                 f'"{value}": the value is not valid'
-            ) from None
-
-        self.manifest = BundleManifest.set_metadata(
-            self._manifest, "publication_season", _value
-        )
+            )
+        else:
+            self.manifest = BundleManifest.set_metadata(
+                self._manifest, "publication_months", _value
+            )
 
     @property
     def volume(self):

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -917,6 +917,59 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
             18,
         )
 
+    def test_publication_month_is_empty_str(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(documents_bundle.publication_month, "")
+
+    def test_set_publication_month(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        documents_bundle.publication_month = "08"
+        self.assertEqual(documents_bundle.publication_month, "08")
+        self.assertEqual(
+            documents_bundle.manifest["metadata"]["publication_month"],
+            [("2018-08-05T22:33:49.795151Z", "08")],
+        )
+
+    def test_set_publication_month_convert_to_str(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        documents_bundle.publication_month = 8
+        self.assertEqual(documents_bundle.publication_month, "08")
+
+    def test_set_publication_month_validates_four_digits_year(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            ValueError,
+            "cannot set publication_month with value " '"Jan": the value is not valid',
+            setattr,
+            documents_bundle,
+            "publication_month",
+            "Jan",
+        )
+
+    def test_publication_season_is_empty_str(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self.assertEqual(documents_bundle.publication_season, "")
+
+    def test_set_publication_season(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        documents_bundle.publication_season = "Jan-Feb"
+        self.assertEqual(documents_bundle.publication_season, "Jan-Feb")
+        self.assertEqual(
+            documents_bundle.manifest["metadata"]["publication_season"],
+            [("2018-08-05T22:33:49.795151Z", "Jan-Feb")],
+        )
+
+    def test_set_publication_season_validates_four_digits_year(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            ValueError,
+            "cannot set publication_season with value " '"8": the value is not valid',
+            setattr,
+            documents_bundle,
+            "publication_season",
+            8,
+        )
+
     def test_volume_is_empty_str(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
         self.assertEqual(documents_bundle.volume, "")

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -948,26 +948,71 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
 
     def test_publication_season_is_empty_str(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        self.assertEqual(documents_bundle.publication_season, [])
+        self.assertEqual(documents_bundle.publication_season, ())
 
     def test_set_publication_season(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.publication_season = [1, 6]
-        self.assertEqual(documents_bundle.publication_season, [1, 6])
+        documents_bundle.publication_season = (1, 6)
+        self.assertEqual(documents_bundle.publication_season, (1, 6))
         self.assertEqual(
             documents_bundle.manifest["metadata"]["publication_season"],
-            [("2018-08-05T22:33:49.795151Z", [1, 6])],
+            [("2018-08-05T22:33:49.795151Z", (1, 6))],
         )
 
-    def test_set_publication_season_validates_four_digits_year(self):
+    def test_set_publication_season_convert_string(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        documents_bundle.publication_season = "1234456"
+        self.assertEqual(
+            documents_bundle.publication_season, ("1", "2", "3", "4", "4", "5", "6")
+        )
+        self.assertEqual(
+            documents_bundle.manifest["metadata"]["publication_season"],
+            [("2018-08-05T22:33:49.795151Z", ("1", "2", "3", "4", "4", "5", "6"))],
+        )
+
+    def test_set_publication_season_validates_repeat_items(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
         self._assert_raises_with_message(
             ValueError,
-            "cannot set publication_season with value " '"[1, 1]": the value is not valid',
+            "cannot set publication_season with value "
+            '"[1, 1]": the value is not valid',
             setattr,
             documents_bundle,
             "publication_season",
             [1, 1],
+        )
+
+    def test_set_publication_season_validates_string_items(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            ValueError,
+            "cannot set publication_season with value "
+            '"abcd": the value is not valid',
+            setattr,
+            documents_bundle,
+            "publication_season",
+            "abcd",
+        )
+
+    def test_set_publication_season_validates_integer(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        self._assert_raises_with_message(
+            ValueError,
+            "cannot set publication_season with value "
+            '"10": the value is not valid',
+            setattr,
+            documents_bundle,
+            "publication_season",
+            10,
+        )
+
+    def test_set_publication_season_convert_to_tuple(self):
+        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
+        documents_bundle.publication_season = [1, 6]
+        self.assertEqual(documents_bundle.publication_season, (1, 6))
+        self.assertEqual(
+            documents_bundle.manifest["metadata"]["publication_season"],
+            [("2018-08-05T22:33:49.795151Z", (1, 6))],
         )
 
     def test_volume_is_empty_str(self):
@@ -1435,7 +1480,7 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "Exact and Earth Sciences",
             "Health Sciences",
             "Human Sciences",
-            "Linguistics, Letters and Arts"
+            "Linguistics, Letters and Arts",
         ]
         self.assertEqual(
             journal.subject_areas,
@@ -1447,7 +1492,7 @@ class JournalTest(UnittestMixin, unittest.TestCase):
                 "Exact and Earth Sciences",
                 "Health Sciences",
                 "Human Sciences",
-                "Linguistics, Letters and Arts"
+                "Linguistics, Letters and Arts",
             ),
         )
         self.assertEqual(
@@ -1462,7 +1507,7 @@ class JournalTest(UnittestMixin, unittest.TestCase):
                     "Exact and Earth Sciences",
                     "Health Sciences",
                     "Human Sciences",
-                    "Linguistics, Letters and Arts"
+                    "Linguistics, Letters and Arts",
                 ),
             ),
         )
@@ -1491,11 +1536,7 @@ class JournalTest(UnittestMixin, unittest.TestCase):
             "APPLIED SOCIAL",
             "BIOLOGICAL",
         )
-        invalid = [
-            "AGRICULTURAL",
-            "APPLIED SOCIAL",
-            "BIOLOGICAL",
-        ]
+        invalid = ["AGRICULTURAL", "APPLIED SOCIAL", "BIOLOGICAL"]
         self._assert_raises_with_message(
             ValueError,
             "cannot set subject_areas with value %s: " % repr(subject_areas)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -917,102 +917,28 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
             18,
         )
 
-    def test_publication_month_is_empty_str(self):
+    def test_publication_months_is_empty_dict(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        self.assertEqual(documents_bundle.publication_month, "")
+        self.assertEqual(documents_bundle.publication_months, {})
 
-    def test_set_publication_month(self):
+    def test_set_publication_months(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.publication_month = "08"
-        self.assertEqual(documents_bundle.publication_month, "08")
+        documents_bundle.publication_months = {"start": "08", "end": "09"}
+        self.assertEqual(documents_bundle.publication_months, {"start": "08", "end": "09"})
         self.assertEqual(
-            documents_bundle.manifest["metadata"]["publication_month"],
-            [("2018-08-05T22:33:49.795151Z", "08")],
+            documents_bundle.manifest["metadata"]["publication_months"],
+            [("2018-08-05T22:33:49.795151Z", {"start": "08", "end": "09"})],
         )
 
-    def test_set_publication_month_convert_to_str(self):
-        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.publication_month = 8
-        self.assertEqual(documents_bundle.publication_month, "08")
-
-    def test_set_publication_month_validates_four_digits_year(self):
+    def test_set_publication_months_validates_not_dict(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
         self._assert_raises_with_message(
             ValueError,
-            "cannot set publication_month with value " '"Jan": the value is not valid',
+            "cannot set publication_months with value " '"Jan": the value is not valid',
             setattr,
             documents_bundle,
-            "publication_month",
+            "publication_months",
             "Jan",
-        )
-
-    def test_publication_season_is_empty_str(self):
-        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        self.assertEqual(documents_bundle.publication_season, ())
-
-    def test_set_publication_season(self):
-        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.publication_season = (1, 6)
-        self.assertEqual(documents_bundle.publication_season, (1, 6))
-        self.assertEqual(
-            documents_bundle.manifest["metadata"]["publication_season"],
-            [("2018-08-05T22:33:49.795151Z", (1, 6))],
-        )
-
-    def test_set_publication_season_convert_string(self):
-        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.publication_season = "1234456"
-        self.assertEqual(
-            documents_bundle.publication_season, ("1", "2", "3", "4", "4", "5", "6")
-        )
-        self.assertEqual(
-            documents_bundle.manifest["metadata"]["publication_season"],
-            [("2018-08-05T22:33:49.795151Z", ("1", "2", "3", "4", "4", "5", "6"))],
-        )
-
-    def test_set_publication_season_validates_repeat_items(self):
-        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        self._assert_raises_with_message(
-            ValueError,
-            "cannot set publication_season with value "
-            '"[1, 1]": the value is not valid',
-            setattr,
-            documents_bundle,
-            "publication_season",
-            [1, 1],
-        )
-
-    def test_set_publication_season_validates_string_items(self):
-        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        self._assert_raises_with_message(
-            ValueError,
-            "cannot set publication_season with value "
-            '"abcd": the value is not valid',
-            setattr,
-            documents_bundle,
-            "publication_season",
-            "abcd",
-        )
-
-    def test_set_publication_season_validates_integer(self):
-        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        self._assert_raises_with_message(
-            ValueError,
-            "cannot set publication_season with value "
-            '"10": the value is not valid',
-            setattr,
-            documents_bundle,
-            "publication_season",
-            10,
-        )
-
-    def test_set_publication_season_convert_to_tuple(self):
-        documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.publication_season = [1, 6]
-        self.assertEqual(documents_bundle.publication_season, (1, 6))
-        self.assertEqual(
-            documents_bundle.manifest["metadata"]["publication_season"],
-            [("2018-08-05T22:33:49.795151Z", (1, 6))],
         )
 
     def test_volume_is_empty_str(self):

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -948,26 +948,26 @@ class DocumentsBundleTest(UnittestMixin, unittest.TestCase):
 
     def test_publication_season_is_empty_str(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        self.assertEqual(documents_bundle.publication_season, "")
+        self.assertEqual(documents_bundle.publication_season, [])
 
     def test_set_publication_season(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
-        documents_bundle.publication_season = "Jan-Feb"
-        self.assertEqual(documents_bundle.publication_season, "Jan-Feb")
+        documents_bundle.publication_season = [1, 6]
+        self.assertEqual(documents_bundle.publication_season, [1, 6])
         self.assertEqual(
             documents_bundle.manifest["metadata"]["publication_season"],
-            [("2018-08-05T22:33:49.795151Z", "Jan-Feb")],
+            [("2018-08-05T22:33:49.795151Z", [1, 6])],
         )
 
     def test_set_publication_season_validates_four_digits_year(self):
         documents_bundle = domain.DocumentsBundle(id="0034-8910-rsp-48-2")
         self._assert_raises_with_message(
             ValueError,
-            "cannot set publication_season with value " '"8": the value is not valid',
+            "cannot set publication_season with value " '"[1, 1]": the value is not valid',
             setattr,
             documents_bundle,
             "publication_season",
-            8,
+            [1, 1],
         )
 
     def test_volume_is_empty_str(self):


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR implementa dois novos atributos na classe `domain.DocumentsBundle`, os atributos criados são:
* `publication_season`
* `publication_month`

#### Onde a revisão poderia começar?
Pelos arquivos modificados:
* `documentstore/domain.py`
* `tests/test_domain.py` 

#### Como este poderia ser testado manualmente?
 * `python setup.py test -qv`

#### Algum cenário de contexto que queira dar?
Essas alterações são necessárias para o desenvolvimento do TK #171 e para contemplar o desenvolvimento realizado no scieloorg/document-store-migracao#24

### Screenshots
N/A

#### Quais são tickets relevantes?
close #159
close #170 

### Referências
* Adicionar campo publication_season ao DocumentsBundle #159
* Adicionar o campo/atributo publication_month ao DocumentsBundle #170
