### PR TITLE
Adiciona o campo publication_months

### DIFF
--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -4,7 +4,6 @@ import os
 from pyramid.settings import asbool
 from pyramid.config import Configurator
 from pyramid.httpexceptions import (
-    HTTPOk,
     HTTPNotFound,
     HTTPNoContent,
     HTTPCreated,
@@ -217,6 +216,15 @@ class JournalAOPSchema(colander.MappingSchema):
 class DocumentsBundleSchema(colander.MappingSchema):
     """Representa o schema de dados para registro de Documents Bundle."""
 
+    @colander.instantiate(missing=colander.drop)
+    class publication_months(colander.MappingSchema):
+        month = colander.SchemaNode(colander.Int(), missing=colander.drop)
+
+        @colander.instantiate(missing=colander.drop)
+        class interval(colander.TupleSchema):
+            start_month = colander.SchemaNode(colander.Int(), missing=colander.drop)
+            end_month = colander.SchemaNode(colander.Int(), missing=colander.drop)
+
     publication_year = colander.SchemaNode(colander.Int(), missing=colander.drop)
     supplement = colander.SchemaNode(colander.String(), missing=colander.drop)
     volume = colander.SchemaNode(colander.String(), missing=colander.drop)
@@ -307,6 +315,7 @@ class JournalIssueItem(colander.MappingSchema):
     volume = colander.SchemaNode(colander.String(), missing=colander.drop)
     number = colander.SchemaNode(colander.String(), missing=colander.drop)
     supplement = colander.SchemaNode(colander.String(), missing=colander.drop)
+
 
 class JournalIssuesSchema(colander.MappingSchema):
     """Representa o schema de dados de atualização de fascículos de periódico.

--- a/documentstore/restfulapi.py
+++ b/documentstore/restfulapi.py
@@ -216,12 +216,16 @@ class JournalAOPSchema(colander.MappingSchema):
 class DocumentsBundleSchema(colander.MappingSchema):
     """Representa o schema de dados para registro de Documents Bundle."""
 
-    @colander.instantiate(missing=colander.drop)
+    def combined_validator(node, value):
+        if value.get('month') and value.get('range'):
+            raise colander.Invalid(node, "The month and range fields are mutually exclusive.")
+
+    @colander.instantiate(missing=colander.drop, validator=combined_validator)
     class publication_months(colander.MappingSchema):
         month = colander.SchemaNode(colander.Int(), missing=colander.drop)
 
         @colander.instantiate(missing=colander.drop)
-        class interval(colander.TupleSchema):
+        class range(colander.TupleSchema):
             start_month = colander.SchemaNode(colander.Int(), missing=colander.drop)
             end_month = colander.SchemaNode(colander.Int(), missing=colander.drop)
 

--- a/tests/apptesting.py
+++ b/tests/apptesting.py
@@ -158,6 +158,7 @@ def documents_bundle_registry_data_fixture():
         "supplement": "1",
         "volume": "1",
         "number": "1",
+        "publication_months": {'month': 1},
         "titles": [
             {
                 "language": "es",

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,7 +1,6 @@
 import json
 import unittest
 from unittest.mock import Mock
-from copy import deepcopy
 
 from documentstore import adapters, domain, exceptions, interfaces
 from . import apptesting
@@ -357,7 +356,7 @@ class ChangesStoreTest(ChangesStoreTestMixin, unittest.TestCase):
 
 class MongoDBTests(unittest.TestCase):
     def test_mongoclient_isnt_instantiated_during_init(self):
-        """É importante que a instância de `pymongo.MongoClient` não seja 
+        """É importante que a instância de `pymongo.MongoClient` não seja
         criada durante a inicialização de `adapters.MongoDB`, mas apenas quando
         a conexão com o banco for necessária. Essa medida visa evitar problemas
         em aplicações que operam no modelo *prefork* como é o caso do Gunicorn.

--- a/tests/test_restfulapi.py
+++ b/tests/test_restfulapi.py
@@ -222,6 +222,16 @@ class DocumentsBundleSchemaTest(unittest.TestCase):
         data = apptesting.documents_bundle_registry_data_fixture()
         restfulapi.DocumentsBundleSchema().deserialize(data)
 
+    def test_if_month_and_range_are_mutually_exclusive(self):
+        data = apptesting.documents_bundle_registry_data_fixture()
+        pub_months_dict = data['publication_months']
+        pub_months_dict['range'] = (1, 2)
+        data['publication_months'] = pub_months_dict
+
+        self.assertRaises(
+            colander.Invalid, restfulapi.JournalIssuesSchema().deserialize, data
+        )
+
 
 class PutDocumentsBundleTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona o campo publication_months.

#### Onde a revisão poderia começar?

No módulo: **documentstore/restfulapi.py**

#### Como este poderia ser testado manualmente?

python setup.py test

#### Algum cenário de contexto que queira dar?

Definimos que esse campo seria no seguinte formato: 

```python 
publication_months = {"month": 1} ou 
publication_months = {"interval": [1, 2]}.
```

### Screenshots
Não há 

#### Quais são tickets relevantes?

Ticket relevante: https://github.com/scieloorg/document-store/issues/171

### Referências
Não há.
