### PR TITLE
Adiciona suporte a replica sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,23 @@ Para mais informação sobre a nova arquitetura de sistemas de informação da M
 Configurando a aplicação:
 
 
-diretiva no arquivo .ini      | variável de ambiente          | valor padrão
-------------------------------|-------------------------------|--------------------
-kernel.app.mongodb.dsn        | KERNEL_APP_MONGODB_DSN        | mongodb://db:27017
-kernel.app.prometheus.enabled | KERNEL_APP_PROMETHEUS_ENABLED | True
-kernel.app.prometheus.port    | KERNEL_APP_PROMETHEUS_PORT    | 8087
+diretiva no arquivo .ini          | variável de ambiente              | valor padrão
+----------------------------------|-----------------------------------|--------------------
+kernel.app.mongodb.dsn            | KERNEL_APP_MONGODB_DSN            | mongodb://db:27017
+kernel.app.mongodb.replicaset     | KERNEL_APP_MONGODB_REPLICASET     |
+kernel.app.mongodb.readpreference | KERNEL_APP_MONGODB_READPREFERENCE | secondaryPreferred
+kernel.app.prometheus.enabled     | KERNEL_APP_PROMETHEUS_ENABLED     | True
+kernel.app.prometheus.port        | KERNEL_APP_PROMETHEUS_PORT        | 8087
+
+
+A configuração padrão assume o uso de uma instância *standalone* do MongoDB. Para
+uma instância de produção recomenda-se o uso de *replica sets*. Para mais detalhes
+acesse https://docs.mongodb.com/manual/replication/.
+
+Ao conectar-se a um *replica set*, a diretiva `kernel.app.mongodb.replicaset`
+deve ser definida com o nome do *replica set*. Além disso, é possível informar os diversos
+*seeds* do *replica set* por meio da diretiva `kernel.app.mongodb.dsn`,
+separando suas URIs com espaços em branco ou quebra de linha.
 
 
 Configurações avançadas:

--- a/development.ini
+++ b/development.ini
@@ -8,7 +8,9 @@ pyramid.debug_routematch = false
 pyramid.debug_templates = true
 pyramid.default_locale_name = en
 
-;kernel.app.mongodb.dsn=
+kernel.app.mongodb.dsn=mongodb://localhost:27017
+;kernel.app.mongodb.replicaset=
+;kernel.app.mongodb.readpreference=
 ;kernel.app.prometheus.enabled=
 ;kernel.app.prometheus.port=
 

--- a/documentstore/adapters.py
+++ b/documentstore/adapters.py
@@ -26,21 +26,34 @@ class MongoDB:
     código necessita conhecer detalhes de conexão, nome do banco de dados ou
     das coleções que armazenam cada tipo de entidade. Caso seja necessário criar
     índices, aqui é o lugar.
+
+    :param options: (opcional) dicionário com opções que serão passadas diretamente
+    na instanciação de `pymongo.MongoClient`. Veja as opções em:
+    https://api.mongodb.com/python/current/api/pymongo/mongo_client.html
     """
 
-    def __init__(self, uri, dbname="document-store", mongoclient=pymongo.MongoClient):
+    def __init__(
+        self,
+        uri,
+        dbname="document-store",
+        mongoclient=pymongo.MongoClient,
+        options=None,
+    ):
         self._dbname = dbname
         self._uri = uri
         self._MongoClient = mongoclient
         self._client_instance = None
+        self._options = options or {}
 
     @property
     def _client(self):
         """Posterga a instanciação de `pymongo.MongoClient` até o seu primeiro
         uso.
         """
+        options = {k: v for k, v in self._options.items() if v}
+
         if not self._client_instance:
-            self._client_instance = self._MongoClient(self._uri)
+            self._client_instance = self._MongoClient(self._uri, **options)
             LOGGER.debug(
                 "new MongoDB client created: <%s at %s>",
                 repr(self._client_instance),

--- a/production.ini
+++ b/production.ini
@@ -9,6 +9,8 @@ pyramid.debug_templates = false
 pyramid.default_locale_name = en
 
 ;kernel.app.mongodb.dsn =
+;kernel.app.mongodb.replicaset=
+;kernel.app.mongodb.readpreference=
 ;kernel.app.prometheus.enabled=
 ;kernel.app.prometheus.port=
 


### PR DESCRIPTION
#### O que esse PR faz?
Inclui diretivas de configuração específicas para a operação com replica
sets do MongoDB. A diretiva `kernel.app.mongodb.dsn` agora pode também
receber uma lista de URIs separadas por espaço em branco ou quebra de
linha, representando *seeds* do replica set.

As seguintes diretivas foram incluídas:
* `kernel.app.mongodb.replicaset`: o nome do replica set para se
conectar;
* `kernel.app.mongodb.readpreference`: a preferência de leitura dentre
os nós do replica set. Por padrão as leituras serão realizadas no nó
secundário e, caso ele esteja indisponível, no primário. Trata-se de uma
estratégia para aumentar a diponibilidade do serviço.

#### Onde a revisão poderia começar?
Pelo README e pela classe `adapters.MongoDB`.

#### Como este poderia ser testado manualmente?
Você precisará inicializar um *replica set* local, conforme descrito em https://api.mongodb.com/python/current/examples/high_availability.html#starting-a-replica-set, definir a diretiva `kernel.app.mongodb.replicaset` com o nome utilizado na inicialização do replica set na etapa anterior e executar a aplicação.

Você poderá encerrar e reiniciar as instâncias do MongoDB enquanto dispara requisições para a aplicação e observar que ela segue disponível.

#### Algum cenário de contexto que queira dar?
O suporte a replica sets é necessário para uma implantação em produção, e portanto deve ser resolvido para que tenhamos uma instância da aplicação rodando na infraestrutura do SciELO.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
* https://api.mongodb.com/python/current/examples/high_availability.html
